### PR TITLE
refactor: #310 - Actualiza las rutas de informes para utilizar permisos específicos en lugar de roles, mejorando la gestión de acceso a los reportes.

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -139,21 +139,23 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::post('/orders/pay', [OrderController::class, 'payOrder']);
 
 
-    Route::middleware(['auth:sanctum', 'role:admin|superadmin|supervisor'])->group(function () {
+    Route::middleware(['auth:sanctum', 'permission:read-all-reports'])->group(function () {
 
-        Route::post('/orders/reports/transactions/export', [ReportController::class, 'export']);
-        Route::post('/orders/reports/municipalities/export', [ReportController::class, 'exportTopMunicipalities']);
-        Route::post('/orders/reports/products/export', [ReportController::class, 'exportTopProducts']);
-        Route::post('/orders/reports/categories/export', [ReportController::class, 'exportTopCategories']);
-        Route::post('/orders/reports/export', [ReportController::class, 'ordersReportExport']);
+        // Export endpoints
+        Route::post('/reports/transactions/export', [ReportController::class, 'export']);
+        Route::post('/reports/municipalities/export', [ReportController::class, 'exportTopMunicipalities']);
+        Route::post('/reports/products/export', [ReportController::class, 'exportTopProducts']);
+        Route::post('/reports/categories/export', [ReportController::class, 'exportTopCategories']);
+        Route::post('/reports/customers/export', [ReportController::class, 'clientsExport']);
+        Route::post('/reports/orders/export', [ReportController::class, 'ordersReportExport']);
 
-        Route::post('/orders/reports', [ReportController::class, 'report']);
-        Route::post('/orders/reports/top-product-list', [ReportController::class, 'productsSalesList']);
-        Route::post('/orders/reports/transactions-list', [ReportController::class, 'transactionsList']);
-        Route::post('/orders/reports/clients-list', [ReportController::class, 'clientsList']);
-        Route::post('/orders/reports/clients/export', [ReportController::class, 'clientsExport']);
-        Route::post('/orders/reports/failed-transactions-list', [ReportController::class, 'failedTransactionsList']);
-        Route::get('/orders/reports/transaction/{id}', [ReportController::class, 'transactionId']);
+        // Dashboard and data endpoints
+        Route::post('/reports/dashboard', [ReportController::class, 'report']);
+        Route::post('/reports/products/top-selling', [ReportController::class, 'productsSalesList']);
+        Route::post('/reports/transactions', [ReportController::class, 'transactionsList']);
+        Route::post('/reports/customers', [ReportController::class, 'clientsList']);
+        Route::post('/reports/transactions/failed', [ReportController::class, 'failedTransactionsList']);
+        Route::get('/reports/transactions/{id}', [ReportController::class, 'transactionId']);
 
     });
 


### PR DESCRIPTION

Esta *pull request* actualiza las rutas de la API para los endpoints de reportes, con el objetivo de mejorar la claridad y la seguridad. Los principales cambios incluyen la reorganización de las rutas relacionadas con reportes, la actualización de su estructura de URL para mayor consistencia y el fortalecimiento del control de acceso mediante la transición de *middleware* basado en roles a uno basado en permisos.

### **Mejoras en el enrutamiento y control de acceso:**

* Se cambió el *middleware* de las rutas de reportes de `role:admin|superadmin|supervisor` a `permission:read-all-reports` para un control de acceso más granular.
* Se actualizaron y reorganizaron las URLs de las rutas relacionadas con reportes para mayor claridad y consistencia (por ejemplo, `/orders/reports/products/export` → `/reports/products/export`).

### **Cambios en nombres y agrupación de endpoints:**

* Se renombraron endpoints y se agruparon por función (por ejemplo, endpoints de exportación, endpoints de dashboard/datos) para mejorar el mantenimiento y la legibilidad.
* Se cambiaron algunos nombres de recursos en las URLs para mantener la coherencia (por ejemplo, `/clients-list` → `/customers`, `/clients/export` → `/customers/export`).