### PR TITLE
refactor: #312 - Actualiza permisos y rutas para la gestión de configuraciones de Webpay y contenido

### DIFF
--- a/config/authorization/permissions.php
+++ b/config/authorization/permissions.php
@@ -102,8 +102,6 @@ return [
     'read-content-settings', //[superadmin, admin, editor]
     'update-content-settings', //[superadmin, admin, editor]
 
-    "edit-content", // [DEPRECATED]
-
     // System settings permissions
     'read-all-system-config', // [superadmin, admin]
     'update-system-config', //[superadmin, admin]

--- a/config/authorization/roles.php
+++ b/config/authorization/roles.php
@@ -47,7 +47,6 @@ return [
         "see-all-products",
         "see-all-clients",
         "see-all-purchases",
-        "edit-content",
         "edit-products",
 
         // Address related permissions
@@ -110,7 +109,6 @@ return [
         "see-all-products",
         "see-all-clients",
         "see-all-purchases",
-        "edit-content",
         "edit-products",
 
         // Address related permissions
@@ -175,7 +173,6 @@ return [
 
         "see-own-purchases",
         "see-all-products",
-        "edit-content",
 
         // FAQ related permissions
         "read-all-faqs",

--- a/routes/api.php
+++ b/routes/api.php
@@ -195,26 +195,31 @@ Route::get('/webpay/return', [WebpayController::class, 'return'])->name('webpay.
 Route::get('/webpay/status', [WebpayController::class, 'status']);
 Route::post('/webpay/refund', [WebpayController::class, 'refund']);
 
-// Configuraciones de Webpay - Solo superadmin puede editarlas
-Route::get('/webpay/config', [SiteinfoController::class, 'webpayConfig']);
-Route::middleware(['auth:sanctum', 'role:superadmin'])->group(function () {
+// Configuraciones de Webpay
+Route::get('/webpay/config', [SiteinfoController::class, 'webpayConfig'])->middleware(['auth:sanctum', 'permission:read-all-system-config']);
+Route::middleware(['auth:sanctum', 'permission:update-system-config'])->group(function () {
     Route::put('/webpay/config', [SiteinfoController::class, 'updateWebpayConfig']);
 });
 
-Route::get('/siteinfo', [SiteinfoController::class, 'show']);
-Route::get('/terms', [SiteinfoController::class, 'terms']);
-Route::get('/privacy-policy', [SiteinfoController::class, 'privacyPolicy']);
-Route::get('/customer-message', [SiteinfoController::class, 'customerMessage']);
+// Configuraciones de contenido - lectura con permiso
+Route::get('/siteinfo', [SiteinfoController::class, 'show'])->middleware(['auth:sanctum', 'permission:read-content-settings']);
+Route::get('/terms', [SiteinfoController::class, 'terms'])->middleware(['auth:sanctum', 'permission:read-content-settings']);
+Route::get('/privacy-policy', [SiteinfoController::class, 'privacyPolicy'])->middleware(['auth:sanctum', 'permission:read-content-settings']);
+Route::get('/customer-message', [SiteinfoController::class, 'customerMessage'])->middleware(['auth:sanctum', 'permission:read-content-settings']);
 
-Route::middleware(['auth:sanctum', 'role:editor|admin|superadmin'])->group(function () {
+// Configuraciones de contenido - actualización
+Route::middleware(['auth:sanctum', 'permission:update-content-settings'])->group(function () {
     Route::put('/siteinfo', [SiteinfoController::class, 'update']);
     Route::put('/terms', [SiteinfoController::class, 'updateTerms']);
     Route::put('/privacy-policy', [SiteinfoController::class, 'updatePrivacyPolicy']);
-    Route::post('/customer-message', [SiteinfoController::class, 'updateCustomerMessage']);
+    Route::put('/customer-message', [SiteinfoController::class, 'updateCustomerMessage']);
 });
 
-Route::middleware(['auth:sanctum', 'role:admin|superadmin'])->group(function () {
+// Configuración de precios
+Route::middleware(['auth:sanctum', 'permission:read-content-settings'])->group(function () {
     Route::get('/settings/prices', [SettingsController::class, 'index']);
+});
+Route::middleware(['auth:sanctum', 'permission:update-content-settings'])->group(function () {
     Route::put('/settings/prices', [SettingsController::class, 'update']);
 });
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -202,10 +202,12 @@ Route::middleware(['auth:sanctum', 'permission:update-system-config'])->group(fu
 });
 
 // Configuraciones de contenido - lectura con permiso
-Route::get('/siteinfo', [SiteinfoController::class, 'show'])->middleware(['auth:sanctum', 'permission:read-content-settings']);
-Route::get('/terms', [SiteinfoController::class, 'terms'])->middleware(['auth:sanctum', 'permission:read-content-settings']);
-Route::get('/privacy-policy', [SiteinfoController::class, 'privacyPolicy'])->middleware(['auth:sanctum', 'permission:read-content-settings']);
-Route::get('/customer-message', [SiteinfoController::class, 'customerMessage'])->middleware(['auth:sanctum', 'permission:read-content-settings']);
+Route::middleware(['auth:sanctum', 'permission:read-content-settings'])->group(function () {
+    Route::get('/siteinfo', [SiteinfoController::class, 'show']);
+    Route::get('/terms', [SiteinfoController::class, 'terms']);
+    Route::get('/privacy-policy', [SiteinfoController::class, 'privacyPolicy']);
+    Route::get('/customer-message', [SiteinfoController::class, 'customerMessage']);
+});
 
 // Configuraciones de contenido - actualización
 Route::middleware(['auth:sanctum', 'permission:update-content-settings'])->group(function () {
@@ -219,6 +221,7 @@ Route::middleware(['auth:sanctum', 'permission:update-content-settings'])->group
 Route::middleware(['auth:sanctum', 'permission:read-content-settings'])->group(function () {
     Route::get('/settings/prices', [SettingsController::class, 'index']);
 });
+
 Route::middleware(['auth:sanctum', 'permission:update-content-settings'])->group(function () {
     Route::put('/settings/prices', [SettingsController::class, 'update']);
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -196,25 +196,25 @@ Route::get('/webpay/status', [WebpayController::class, 'status']);
 Route::post('/webpay/refund', [WebpayController::class, 'refund']);
 
 // Configuraciones de Webpay
-Route::get('/webpay/config', [SiteinfoController::class, 'webpayConfig'])->middleware(['auth:sanctum', 'permission:read-all-system-config']);
+Route::get('/webpay/config', [SiteinfoController::class, 'webpayConfig'])->middleware(['auth:sanctum', 'permission:read-all-system-config'])->name('webpay.config');
 Route::middleware(['auth:sanctum', 'permission:update-system-config'])->group(function () {
-    Route::put('/webpay/config', [SiteinfoController::class, 'updateWebpayConfig']);
+    Route::put('/webpay/config', [SiteinfoController::class, 'updateWebpayConfig'])->name('webpay.config.update');
 });
 
 // Configuraciones de contenido - lectura con permiso
 Route::middleware(['auth:sanctum', 'permission:read-content-settings'])->group(function () {
-    Route::get('/siteinfo', [SiteinfoController::class, 'show']);
-    Route::get('/terms', [SiteinfoController::class, 'terms']);
-    Route::get('/privacy-policy', [SiteinfoController::class, 'privacyPolicy']);
-    Route::get('/customer-message', [SiteinfoController::class, 'customerMessage']);
+    Route::get('/siteinfo', [SiteinfoController::class, 'show'])->name('siteinfo.show');
+    Route::get('/terms', [SiteinfoController::class, 'terms'])->name('siteinfo.terms');
+    Route::get('/privacy-policy', [SiteinfoController::class, 'privacyPolicy'])->name('siteinfo.privacy-policy');
+    Route::get('/customer-message', [SiteinfoController::class, 'customerMessage'])->name('siteinfo.customer-message');
 });
 
 // Configuraciones de contenido - actualización
 Route::middleware(['auth:sanctum', 'permission:update-content-settings'])->group(function () {
-    Route::put('/siteinfo', [SiteinfoController::class, 'update']);
-    Route::put('/terms', [SiteinfoController::class, 'updateTerms']);
-    Route::put('/privacy-policy', [SiteinfoController::class, 'updatePrivacyPolicy']);
-    Route::put('/customer-message', [SiteinfoController::class, 'updateCustomerMessage']);
+    Route::put('/siteinfo', [SiteinfoController::class, 'update'])->name('siteinfo.update');
+    Route::put('/terms', [SiteinfoController::class, 'updateTerms'])->name('siteinfo.terms.update');
+    Route::put('/privacy-policy', [SiteinfoController::class, 'updatePrivacyPolicy'])->name('siteinfo.privacy-policy.update');
+    Route::put('/customer-message', [SiteinfoController::class, 'updateCustomerMessage'])->name('siteinfo.customer-message.update');
 });
 
 // Configuración de precios

--- a/tests/Feature/SiteinfoTest.php
+++ b/tests/Feature/SiteinfoTest.php
@@ -7,345 +7,359 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
-use Spatie\Permission\Models\Role;
-use Spatie\Permission\Models\Permission;
 
 uses(RefreshDatabase::class);
 
-// Prepara los roles y permisos necesarios antes de cada test
-beforeEach(function () {
-    // Crear permisos
-    Permission::firstOrCreate(['name' => 'read-content-settings']);
-    Permission::firstOrCreate(['name' => 'update-content-settings']);
-    Permission::firstOrCreate(['name' => 'read-all-system-config']);
-    Permission::firstOrCreate(['name' => 'update-system-config']);
-    
-    // Crear roles
-    Role::firstOrCreate(['name' => 'admin', 'guard_name' => 'web']);
-    Role::firstOrCreate(['name' => 'editor', 'guard_name' => 'web']);
-    Role::firstOrCreate(['name' => 'superadmin', 'guard_name' => 'web']);
-    
-    // Asignar permisos a roles
-    $adminRole = Role::findByName('admin');
-    $adminRole->givePermissionTo(['read-content-settings', 'update-content-settings', 'read-all-system-config', 'update-system-config']);
-    
-    $editorRole = Role::findByName('editor');
-    $editorRole->givePermissionTo(['read-content-settings', 'update-content-settings']);
-    
-    $superadminRole = Role::findByName('superadmin');
-    $superadminRole->givePermissionTo(['read-content-settings', 'update-content-settings', 'read-all-system-config', 'update-system-config']);
+describe('Siteinfo API', function () {
+    describe('Show endpoint', function () {
+        it('requires authentication', function () {
+            $this->getJson(route('siteinfo.show'))->assertUnauthorized();
+        });
+
+        it('requires read-content-settings permission', function () {
+            $user = User::factory()->create(); // User without permission
+            $this->actingAs($user, 'sanctum')
+                ->getJson(route('siteinfo.show'))
+                ->assertForbidden();
+        });
+
+        it('returns default structure when database is empty', function () {
+            $user = User::factory()->create();
+            $user->givePermissionTo('read-content-settings');
+            
+            $this->actingAs($user, 'sanctum')
+                ->getJson(route('siteinfo.show'))
+                ->assertOk()
+                ->assertJsonStructure([
+                    'header' => ['contact_phone', 'contact_email'],
+                    'footer' => ['contact_phone', 'contact_email'],
+                    'social_media' => [['label', 'link']]
+                ]);
+        });
+
+        it('returns saved values from database', function () {
+            $user = User::factory()->create();
+            $user->givePermissionTo('read-content-settings');
+            Siteinfo::create(['key' => 'header', 'value' => ['contact_phone' => '123', 'contact_email' => 'a@b.com']]);
+            Siteinfo::create(['key' => 'footer', 'value' => ['contact_phone' => '456', 'contact_email' => 'c@d.com']]);
+            Siteinfo::create(['key' => 'social_media', 'value' => [['label' => 'fb', 'link' => 'fb.com']]]);
+
+            $this->actingAs($user, 'sanctum')
+                ->getJson(route('siteinfo.show'))
+                ->assertOk()
+                ->assertJson([
+                    'header' => ['contact_phone' => '123', 'contact_email' => 'a@b.com'],
+                    'footer' => ['contact_phone' => '456', 'contact_email' => 'c@d.com'],
+                    'social_media' => [['label' => 'fb', 'link' => 'fb.com']]
+                ]);
+        });
+    });
+
+    describe('Update endpoint', function () {
+        it('requires authentication and correct permission', function () {
+            $this->putJson(route('siteinfo.update'), [])->assertUnauthorized();
+
+            $user = User::factory()->create();
+            $this->actingAs($user, 'sanctum');
+            $this->putJson(route('siteinfo.update'), [])->assertForbidden();
+        });
+
+        it('allows admin to update siteinfo', function () {
+            $user = User::factory()->create();
+            $user->givePermissionTo('update-content-settings');
+
+            $payload = [
+                'header' => ['contact_phone' => '999', 'contact_email' => 'x@y.com'],
+                'footer' => ['contact_phone' => '888', 'contact_email' => 'z@w.com'],
+                'social_media' => [['label' => 'ig', 'link' => 'ig.com']]
+            ];
+
+            $this->actingAs($user, 'sanctum')
+                ->putJson(route('siteinfo.update'), $payload)
+                ->assertOk()
+                ->assertJson(['message' => 'Siteinfo updated successfully']);
+
+            $this->assertDatabaseHas('siteinfo', ['key' => 'header']);
+            $this->assertDatabaseHas('siteinfo', ['key' => 'footer']);
+            $this->assertDatabaseHas('siteinfo', ['key' => 'social_media']);
+        });
+    });
 });
 
-test('show endpoint requires authentication', function () {
-    $this->getJson('/api/siteinfo')->assertUnauthorized();
+describe('Terms and Privacy Policy API', function () {
+    describe('Authentication and Authorization', function () {
+        it('requires authentication for terms and privacy policy', function () {
+            $this->getJson(route('siteinfo.terms'))->assertUnauthorized();
+            $this->getJson(route('siteinfo.privacy-policy'))->assertUnauthorized();
+        });
+
+        it('requires read-content-settings permission', function () {
+            $user = User::factory()->create(); // User without permission
+            $this->actingAs($user, 'sanctum')
+                ->getJson(route('siteinfo.terms'))
+                ->assertForbidden();
+            $this->actingAs($user, 'sanctum')
+                ->getJson(route('siteinfo.privacy-policy'))
+                ->assertForbidden();
+        });
+    });
+
+    describe('Content Display', function () {
+        it('returns correct content for terms and privacy policy', function () {
+            $user = User::factory()->create();
+            $user->givePermissionTo('read-content-settings');
+            Siteinfo::create(['key' => 'terms', 'content' => '<h1>Terms</h1>']);
+            Siteinfo::create(['key' => 'privacy_policy', 'content' => '<h1>Policy</h1>']);
+
+            $this->actingAs($user, 'sanctum')
+                ->getJson(route('siteinfo.terms'))
+                ->assertOk()
+                ->assertJson(['content' => '<h1>Terms</h1>']);
+
+            $this->actingAs($user, 'sanctum')
+                ->getJson(route('siteinfo.privacy-policy'))
+                ->assertOk()
+                ->assertJson(['content' => '<h1>Policy</h1>']);
+        });
+    });
+
+    describe('Content Updates', function () {
+        it('allows editor to update terms and privacy policy', function () {
+            $user = User::factory()->create();
+            $user->givePermissionTo('update-content-settings');
+
+            $this->actingAs($user, 'sanctum');
+
+            $this->putJson(route('siteinfo.terms.update'), ['content' => '<h1>New Terms</h1>'])
+                ->assertOk()
+                ->assertJson(['message' => 'Terms upadated succesfully']);
+
+            $this->putJson(route('siteinfo.privacy-policy.update'), ['content' => '<h1>New Policy</h1>'])
+                ->assertOk()
+                ->assertJson(['message' => 'Privacy Policy updated successfully']);
+
+            $this->assertDatabaseHas('siteinfo', ['key' => 'terms', 'content' => '<h1>New Terms</h1>']);
+            $this->assertDatabaseHas('siteinfo', ['key' => 'privacy_policy', 'content' => '<h1>New Policy</h1>']);
+        });
+    });
 });
 
-test('show endpoint requires read-content-settings permission', function () {
-    $user = User::factory()->create(); // User without permission
-    $this->actingAs($user, 'sanctum')
-        ->getJson('/api/siteinfo')
-        ->assertForbidden();
+describe('Customer Message API', function () {
+    describe('Authentication and Authorization', function () {
+        it('requires authentication', function () {
+            $this->getJson(route('siteinfo.customer-message'))->assertUnauthorized();
+        });
+
+        it('requires read-content-settings permission', function () {
+            $user = User::factory()->create(); // User without permission
+            $this->actingAs($user, 'sanctum')
+                ->getJson(route('siteinfo.customer-message'))
+                ->assertForbidden();
+        });
+    });
+
+    describe('Content Display', function () {
+        it('returns default structure', function () {
+            $user = User::factory()->create();
+            $user->givePermissionTo('read-content-settings');
+            
+            $this->actingAs($user, 'sanctum')
+                ->getJson(route('siteinfo.customer-message'))
+                ->assertOk()
+                ->assertJsonStructure([
+                    'header' => ['color', 'content'],
+                    'banner' => ['desktop_image', 'mobile_image', 'enabled'],
+                    'modal' => ['image', 'enabled']
+                ]);
+        });
+    });
+
+    describe('Content Updates', function () {
+        it('allows superadmin to update customer message without header_content', function () {
+            $user = User::factory()->create();
+            $user->givePermissionTo('update-content-settings');
+
+            $payload = [
+                'header_color' => '#fff',
+                'banner_enabled' => true,
+                'modal_enabled' => true,
+                'message_enabled' => true,
+            ];
+
+            $this->actingAs($user, 'sanctum')
+                ->putJson(route('siteinfo.customer-message.update'), $payload)
+                ->assertOk()
+                ->assertJson(['message' => 'Mensaje de bienvenida actualizado correctamente.']);
+
+            $record = Siteinfo::where('key', 'customer_message')->first();
+            expect($record)->not->toBeNull();
+            expect($record->value['header']['content'])->toBe(''); // Debe ser string vacío
+        });
+
+        it('allows superadmin to update customer message with images', function () {
+            Storage::fake('public');
+            $user = User::factory()->create();
+            $user->givePermissionTo('update-content-settings');
+            $imagePath = public_path('images/test-image.png');
+
+            if (!file_exists($imagePath)) {
+                if (!is_dir(dirname($imagePath))) {
+                    mkdir(dirname($imagePath), 0755, true);
+                }
+                file_put_contents($imagePath, base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='));
+            }
+
+            $payload = [
+                'header_color' => '#fff',
+                'header_content' => '<h1>Hola</h1>',
+                'banner_enabled' => true,
+                'modal_enabled' => true,
+                'message_enabled' => true,
+                'banner_desktop_image' => new UploadedFile($imagePath, 'desktop.png', 'image/png', null, true),
+                'banner_mobile_image' => new UploadedFile($imagePath, 'mobile.png', 'image/png', null, true),
+                'modal_image' => new UploadedFile($imagePath, 'modal.png', 'image/png', null, true),
+            ];
+
+            $this->actingAs($user, 'sanctum')
+                ->putJson(route('siteinfo.customer-message.update'), $payload)
+                ->assertOk()
+                ->assertJson(['message' => 'Mensaje de bienvenida actualizado correctamente.']);
+
+            $record = Siteinfo::where('key', 'customer_message')->first();
+            expect($record)->not->toBeNull();
+
+            expect($record->value['banner']['enabled'])->toBeBool();
+            expect($record->value['modal']['enabled'])->toBeBool();
+            expect($record->value['message']['enabled'])->toBeBool();
+            
+            expect($record->value['banner']['desktop_image'])->toStartWith('http');
+            expect($record->value['banner']['mobile_image'])->toStartWith('http');
+            expect($record->value['modal']['image'])->toStartWith('http');
+        });
+
+        it('allows superadmin to update customer message without images', function () {
+            $user = User::factory()->create();
+            $user->givePermissionTo('update-content-settings');
+
+            $payload = [
+                'header_color' => '#fff',
+                'header_content' => '<h1>Hola</h1>',
+                'banner_enabled' => true,
+                'modal_enabled' => true,
+                'message_enabled' => true,
+            ];
+
+            $this->actingAs($user, 'sanctum')
+                ->putJson(route('siteinfo.customer-message.update'), $payload)
+                ->assertOk()
+                ->assertJson(['message' => 'Mensaje de bienvenida actualizado correctamente.']);
+
+            $record = Siteinfo::where('key', 'customer_message')->first();
+            expect($record)->not->toBeNull();
+
+            // Verifica que los campos booleanos sean booleanos
+            expect($record->value['banner']['enabled'])->toBeBool();
+            expect($record->value['modal']['enabled'])->toBeBool();
+            expect($record->value['message']['enabled'])->toBeBool();
+
+            // Verifica que las imágenes sean string vacíos (no concatenados)
+            expect($record->value['banner']['desktop_image'])->toBe('');
+            expect($record->value['banner']['mobile_image'])->toBe('');
+            expect($record->value['modal']['image'])->toBe('');
+        });
+    });
 });
 
-test('show endpoint returns default structure when database is empty', function () {
-    $user = User::factory()->create()->assignRole('admin');
-    
-    $this->actingAs($user, 'sanctum')
-        ->getJson('/api/siteinfo')
-        ->assertOk()
-        ->assertJsonStructure([
-            'header' => ['contact_phone', 'contact_email'],
-            'footer' => ['contact_phone', 'contact_email'],
-            'social_media' => [['label', 'link']]
-        ]);
-});
+describe('Webpay Configuration API', function () {
+    describe('Authentication and Authorization', function () {
+        it('requires authentication for webpay config', function () {
+            $this->getJson(route('webpay.config'))->assertUnauthorized();
+        });
 
-test('show endpoint returns saved values from database', function () {
-    $user = User::factory()->create()->assignRole('admin');
-    Siteinfo::create(['key' => 'header', 'value' => ['contact_phone' => '123', 'contact_email' => 'a@b.com']]);
-    Siteinfo::create(['key' => 'footer', 'value' => ['contact_phone' => '456', 'contact_email' => 'c@d.com']]);
-    Siteinfo::create(['key' => 'social_media', 'value' => [['label' => 'fb', 'link' => 'fb.com']]]);
+        it('requires read-all-system-config permission', function () {
+            $user = User::factory()->create(); // User without permission
+            $this->actingAs($user, 'sanctum')
+                ->getJson(route('webpay.config'))
+                ->assertForbidden();
+        });
+    });
 
-    $this->actingAs($user, 'sanctum')
-        ->getJson('/api/siteinfo')
-        ->assertOk()
-        ->assertJson([
-            'header' => ['contact_phone' => '123', 'contact_email' => 'a@b.com'],
-            'footer' => ['contact_phone' => '456', 'contact_email' => 'c@d.com'],
-            'social_media' => [['label' => 'fb', 'link' => 'fb.com']]
-        ]);
-});
+    describe('Configuration Display', function () {
+        it('returns default structure when database is empty', function () {
+            $user = User::factory()->create();
+            $user->givePermissionTo('read-all-system-config');
+            
+            $this->actingAs($user, 'sanctum')
+                ->getJson(route('webpay.config'))
+                ->assertStatus(404)
+                ->assertJson([
+                    'message' => 'No se encontró la configuración de Webpay',
+                    'data' => [],
+                ]);
+        });
 
-test('update endpoint requires authentication and correct permission', function () {
-    $this->putJson('/api/siteinfo', [])->assertUnauthorized();
+        it('returns stored values', function () {
+            $user = User::factory()->create();
+            $user->givePermissionTo('read-all-system-config');
+            $stored = [
+                'WEBPAY_COMMERCE_CODE' => '123456',
+                'WEBPAY_API_KEY' => 'SOMEKEY',
+                'WEBPAY_ENVIRONMENT' => 'production',
+                'WEBPAY_RETURN_URL' => 'https://example.com/return',
+            ];
+            Siteinfo::create([
+                'key' => 'WEBPAY_INFO',
+                'value' => $stored,
+                'content' => 'Informacion de entorno webpay',
+            ]);
 
-    $user = User::factory()->create();
-    $this->actingAs($user, 'sanctum');
-    $this->putJson('/api/siteinfo', [])->assertForbidden();
-});
+            $this->actingAs($user, 'sanctum')
+                ->getJson(route('webpay.config'))
+                ->assertOk()
+                ->assertJson($stored);
+        });
+    });
 
-test('an admin can update siteinfo', function () {
-    $user = User::factory()->create()->assignRole('admin');
+    describe('Configuration Updates', function () {
+        it('requires authentication and update-system-config permission', function () {
+            $payload = [
+                'WEBPAY_COMMERCE_CODE' => '111',
+                'WEBPAY_API_KEY' => 'KEY',
+                'WEBPAY_ENVIRONMENT' => 'integration',
+                'WEBPAY_RETURN_URL' => 'https://abc.com',
+            ];
 
-    $payload = [
-        'header' => ['contact_phone' => '999', 'contact_email' => 'x@y.com'],
-        'footer' => ['contact_phone' => '888', 'contact_email' => 'z@w.com'],
-        'social_media' => [['label' => 'ig', 'link' => 'ig.com']]
-    ];
+            // Unauthenticated
+            $this->putJson(route('webpay.config.update'), $payload)->assertUnauthorized();
 
-    $this->actingAs($user, 'sanctum')
-        ->putJson('/api/siteinfo', $payload)
-        ->assertOk()
-        ->assertJson(['message' => 'Siteinfo updated successfully']);
+            // Authenticated but without permission (user doesn't have system config permission)
+            $user = User::factory()->create();
+            $this->actingAs($user, 'sanctum');
+            $this->putJson(route('webpay.config.update'), $payload)->assertForbidden();
+        });
 
-    $this->assertDatabaseHas('siteinfo', ['key' => 'header']);
-    $this->assertDatabaseHas('siteinfo', ['key' => 'footer']);
-    $this->assertDatabaseHas('siteinfo', ['key' => 'social_media']);
-});
+        it('allows user with update-system-config permission to update webpay config', function () {
+            $user = User::factory()->create();
+            $user->givePermissionTo('update-system-config');
 
-test('terms and privacy policy endpoints require authentication', function () {
-    $this->getJson('/api/terms')->assertUnauthorized();
-    $this->getJson('/api/privacy-policy')->assertUnauthorized();
-});
+            $payload = [
+                'WEBPAY_COMMERCE_CODE' => '7654321',
+                'WEBPAY_API_KEY' => 'NEWKEY',
+                'WEBPAY_ENVIRONMENT' => 'integration',
+                'WEBPAY_RETURN_URL' => 'https://mysite.com/webpay/return',
+            ];
 
-test('terms and privacy policy endpoints require read-content-settings permission', function () {
-    $user = User::factory()->create(); // User without permission
-    $this->actingAs($user, 'sanctum')
-        ->getJson('/api/terms')
-        ->assertForbidden();
-    $this->actingAs($user, 'sanctum')
-        ->getJson('/api/privacy-policy')
-        ->assertForbidden();
-});
+            $this->actingAs($user, 'sanctum')
+                ->putJson(route('webpay.config.update'), $payload)
+                ->assertOk()
+                ->assertJson(['message' => 'Configuración de Webpay actualizada exitosamente']);
 
-test('terms and privacy policy endpoints return correct content', function () {
-    $user = User::factory()->create()->assignRole('admin');
-    Siteinfo::create(['key' => 'terms', 'content' => '<h1>Terms</h1>']);
-    Siteinfo::create(['key' => 'privacy_policy', 'content' => '<h1>Policy</h1>']);
+            $this->assertDatabaseHas('siteinfo', [
+                'key' => 'WEBPAY_INFO',
+            ]);
 
-    $this->actingAs($user, 'sanctum')
-        ->getJson('/api/terms')
-        ->assertOk()
-        ->assertJson(['content' => '<h1>Terms</h1>']);
-
-    $this->actingAs($user, 'sanctum')
-        ->getJson('/api/privacy-policy')
-        ->assertOk()
-        ->assertJson(['content' => '<h1>Policy</h1>']);
-});
-
-test('an editor can update terms and privacy policy', function () {
-    $user = User::factory()->create()->assignRole('editor');
-
-    $this->actingAs($user, 'sanctum');
-
-    $this->putJson('/api/terms', ['content' => '<h1>New Terms</h1>'])
-        ->assertOk()
-        ->assertJson(['message' => 'Terms upadated succesfully']);
-
-    $this->putJson('/api/privacy-policy', ['content' => '<h1>New Policy</h1>'])
-        ->assertOk()
-        ->assertJson(['message' => 'Privacy Policy updated successfully']);
-
-    $this->assertDatabaseHas('siteinfo', ['key' => 'terms', 'content' => '<h1>New Terms</h1>']);
-    $this->assertDatabaseHas('siteinfo', ['key' => 'privacy_policy', 'content' => '<h1>New Policy</h1>']);
-});
-
-test('customer message endpoint requires authentication', function () {
-    $this->getJson('/api/customer-message')->assertUnauthorized();
-});
-
-test('customer message endpoint requires read-content-settings permission', function () {
-    $user = User::factory()->create(); // User without permission
-    $this->actingAs($user, 'sanctum')
-        ->getJson('/api/customer-message')
-        ->assertForbidden();
-});
-
-test('customer message endpoint returns default structure', function () {
-    $user = User::factory()->create()->assignRole('admin');
-    
-    $this->actingAs($user, 'sanctum')
-        ->getJson('/api/customer-message')
-        ->assertOk()
-        ->assertJsonStructure([
-            'header' => ['color', 'content'],
-            'banner' => ['desktop_image', 'mobile_image', 'enabled'],
-            'modal' => ['image', 'enabled']
-        ]);
-});
-
-test('a superadmin can update customer message without header_content', function () {
-    $user = User::factory()->create()->assignRole('superadmin');
-
-    $payload = [
-        'header_color' => '#fff',
-        'banner_enabled' => true,
-        'modal_enabled' => true,
-        'message_enabled' => true,
-    ];
-
-    $this->actingAs($user, 'sanctum')
-        ->putJson('/api/customer-message', $payload)
-        ->assertOk()
-        ->assertJson(['message' => 'Mensaje de bienvenida actualizado correctamente.']);
-
-    $record = Siteinfo::where('key', 'customer_message')->first();
-    expect($record)->not->toBeNull();
-    expect($record->value['header']['content'])->toBe(''); // Debe ser string vacío
-});
-
-test('a superadmin can update customer message with images', function () {
-    Storage::fake('public');
-    $user = User::factory()->create()->assignRole('superadmin');
-    $imagePath = public_path('images/test-image.png');
-
-    if (!file_exists($imagePath)) {
-        if (!is_dir(dirname($imagePath))) {
-            mkdir(dirname($imagePath), 0755, true);
-        }
-        file_put_contents($imagePath, base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='));
-    }
-
-    $payload = [
-        'header_color' => '#fff',
-        'header_content' => '<h1>Hola</h1>',
-        'banner_enabled' => true,
-        'modal_enabled' => true,
-        'message_enabled' => true,
-        'banner_desktop_image' => new UploadedFile($imagePath, 'desktop.png', 'image/png', null, true),
-        'banner_mobile_image' => new UploadedFile($imagePath, 'mobile.png', 'image/png', null, true),
-        'modal_image' => new UploadedFile($imagePath, 'modal.png', 'image/png', null, true),
-    ];
-
-    $this->actingAs($user, 'sanctum')
-        ->putJson('/api/customer-message', $payload)
-        ->assertOk()
-        ->assertJson(['message' => 'Mensaje de bienvenida actualizado correctamente.']);
-
-    $record = Siteinfo::where('key', 'customer_message')->first();
-    expect($record)->not->toBeNull();
-
-    expect($record->value['banner']['enabled'])->toBeBool();
-    expect($record->value['modal']['enabled'])->toBeBool();
-    expect($record->value['message']['enabled'])->toBeBool();
-    
-    expect($record->value['banner']['desktop_image'])->toStartWith('http');
-    expect($record->value['banner']['mobile_image'])->toStartWith('http');
-    expect($record->value['modal']['image'])->toStartWith('http');
-});
-
-test('a superadmin can update customer message without images', function () {
-    $user = User::factory()->create()->assignRole('superadmin');
-
-    $payload = [
-        'header_color' => '#fff',
-        'header_content' => '<h1>Hola</h1>',
-        'banner_enabled' => true,
-        'modal_enabled' => true,
-        'message_enabled' => true,
-    ];
-
-    $this->actingAs($user, 'sanctum')
-        ->putJson('/api/customer-message', $payload)
-        ->assertOk()
-        ->assertJson(['message' => 'Mensaje de bienvenida actualizado correctamente.']);
-
-    $record = Siteinfo::where('key', 'customer_message')->first();
-    expect($record)->not->toBeNull();
-
-    // Verifica que los campos booleanos sean booleanos
-    expect($record->value['banner']['enabled'])->toBeBool();
-    expect($record->value['modal']['enabled'])->toBeBool();
-    expect($record->value['message']['enabled'])->toBeBool();
-
-    // Verifica que las imágenes sean string vacíos (no concatenados)
-    expect($record->value['banner']['desktop_image'])->toBe('');
-    expect($record->value['banner']['mobile_image'])->toBe('');
-    expect($record->value['modal']['image'])->toBe('');
-});
-
-// Webpay tests
-
-test('webpay config endpoint requires authentication', function () {
-    $this->getJson('/api/webpay/config')->assertUnauthorized();
-});
-
-test('webpay config endpoint requires read-all-system-config permission', function () {
-    $user = User::factory()->create(); // User without permission
-    $this->actingAs($user, 'sanctum')
-        ->getJson('/api/webpay/config')
-        ->assertForbidden();
-});
-
-test('webpay config endpoint returns default structure when database is empty', function () {
-    $user = User::factory()->create()->assignRole('admin');
-    
-    $this->actingAs($user, 'sanctum')
-        ->getJson('/api/webpay/config')
-        ->assertStatus(404)
-        ->assertJson([
-            'message' => 'No se encontró la configuración de Webpay',
-            'data' => [],
-        ]);
-});
-
-test('webpay config endpoint returns stored values', function () {
-    $user = User::factory()->create()->assignRole('admin');
-    $stored = [
-        'WEBPAY_COMMERCE_CODE' => '123456',
-        'WEBPAY_API_KEY' => 'SOMEKEY',
-        'WEBPAY_ENVIRONMENT' => 'production',
-        'WEBPAY_RETURN_URL' => 'https://example.com/return',
-    ];
-    Siteinfo::create([
-        'key' => 'WEBPAY_INFO',
-        'value' => $stored,
-        'content' => 'Informacion de entorno webpay',
-    ]);
-
-    $this->actingAs($user, 'sanctum')
-        ->getJson('/api/webpay/config')
-        ->assertOk()
-        ->assertJson($stored);
-});
-
-test('update webpay config requires authentication and update-system-config permission', function () {
-    $payload = [
-        'WEBPAY_COMMERCE_CODE' => '111',
-        'WEBPAY_API_KEY' => 'KEY',
-        'WEBPAY_ENVIRONMENT' => 'integration',
-        'WEBPAY_RETURN_URL' => 'https://abc.com',
-    ];
-
-    // Unauthenticated
-    $this->putJson('/api/webpay/config', $payload)->assertUnauthorized();
-
-    // Authenticated but without permission (editor doesn't have system config permission)
-    $user = User::factory()->create()->assignRole('editor');
-    $this->actingAs($user, 'sanctum');
-    $this->putJson('/api/webpay/config', $payload)->assertForbidden();
-});
-
-test('a user with update-system-config permission can update webpay config', function () {
-    $user = User::factory()->create()->assignRole('admin');
-
-    $payload = [
-        'WEBPAY_COMMERCE_CODE' => '7654321',
-        'WEBPAY_API_KEY' => 'NEWKEY',
-        'WEBPAY_ENVIRONMENT' => 'integration',
-        'WEBPAY_RETURN_URL' => 'https://mysite.com/webpay/return',
-    ];
-
-    $this->actingAs($user, 'sanctum')
-        ->putJson('/api/webpay/config', $payload)
-        ->assertOk()
-        ->assertJson(['message' => 'Configuración de Webpay actualizada exitosamente']);
-
-    $this->assertDatabaseHas('siteinfo', [
-        'key' => 'WEBPAY_INFO',
-    ]);
-
-    $record = Siteinfo::where('key', 'WEBPAY_INFO')->first();
-    expect($record->value)->toMatchArray($payload);
+            $record = Siteinfo::where('key', 'WEBPAY_INFO')->first();
+            expect($record->value)->toMatchArray($payload);
+        });
+    });
 });


### PR DESCRIPTION
- Elimina el permiso 'edit-content' de los archivos de permisos y roles.
- Modifica las rutas en `routes/api.php` para requerir permisos específicos en lugar de roles para acceder a las configuraciones de Webpay y contenido.
- Agrega pruebas en `SettingsTest.php` y `SiteinfoTest.php` para verificar el acceso basado en permisos en las configuraciones de contenido y Webpay.

<img width="797" height="620" alt="image" src="https://github.com/user-attachments/assets/60667bbc-1e7c-4f4a-abca-d11a45ca3aca" />
