### PR TITLE
Feat/random users sync adjustments

### DIFF
--- a/app/Console/Commands/FixRandomUsers.php
+++ b/app/Console/Commands/FixRandomUsers.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use App\Services\RandomApiService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class FixRandomUsers extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'random:fix-users';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Fix random users';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(RandomApiService $random)
+    {
+        Log::info('SyncRandomUsers started');
+
+        /** @var array $entidades */
+        $entidades = $random->fetchAndUpdateUsers();
+
+
+        foreach ($entidades as $entidad) {
+            try {
+                if ($entidad['TIPOSUC'] == 'P') { //Sincroniza solo si es sucursal principal
+
+                    $user = User::where('user_code', $entidad['KOEN'])->first();
+                    $rten = User::where('rut', $entidad['RTEN'])->first();
+
+                    if ($user && $rten && $user->id !== $rten->id) {
+                        Log::warning('Skipping random user sync', [
+                            'message' => 'RUT already exists in the database',
+                            'user_found_by_code' => $user->toArray(),
+                            'user_found_by_rut' => $rten->toArray(),
+                            'entidad_random' => $entidad,
+                        ]);
+                        continue;
+                    }
+
+                    if ($user === null) {
+                        $user = new User();
+                    }
+
+                    $email = trim($entidad['EMAILCOMER'] ?? '') ?: null;
+                    if (!$email) {
+                        // Generar email temporal basado en RUT
+                        $rut = $entidad['KOEN'] ?? 'user';
+                        $email = "temp_{$rut}@socomarca.temp";
+                    }
+
+                    if (\App\Models\User::where('email', $email)->exists() && $user->id === null) {
+                        Log::warning('Skipping random user sync', [
+                            'message' => 'Email address already exists in the database',
+                            'user' => $user->toArray(),
+                            'entidad_random' => $entidad,
+                            'email' => $email,
+                        ]);
+                        continue;
+                    }
+
+                    Log::info('Processing user', ['user' => $user->toArray()]);
+
+                    $user->rut          = $entidad['RTEN'];
+                    $user->name          = $entidad['NOKOEN'] ?? '';
+                    $user->email         = $email;
+                    $user->business_name = '';
+                    $user->is_active     = true;
+                    $user->phone         = $entidad['FOEN'] ?? null;
+                    $user->branch_code = $entidad['SUEN'] ?? '';
+                    $user->random_user_type = $entidad['TIEN'];
+
+                    // Solo asigna password si es un usuario nuevo
+                    if (!$user->exists) {
+                        $user->password = bcrypt('password');
+                    }
+
+                    $user->save();
+                    $user->refresh();
+
+                    if (in_array($user->random_user_type, ['C', 'A'])) {
+                        $user->assignRole('customer');
+                        Log::debug('Customer role assigned to user');
+                    }
+
+                    Log::info("User {$user->id}, with RUT {$user->rut} and code {$user->user_code} synced successfully");
+                }
+            } catch (\Throwable $e) {
+                # code...
+                Log::error('SyncRandomUsers failed: ' . $e->getMessage());
+                return;
+            }
+        }
+    }
+}

--- a/app/Http/Controllers/Api/CreditLineController.php
+++ b/app/Http/Controllers/Api/CreditLineController.php
@@ -18,7 +18,7 @@ class CreditLineController extends Controller
     {
         $response = $this->randomApiService->getCreditLine(
             $user->rut,
-            $user->sucursal_code
+            $user->branch_code
         );
 
         $data = $response->json();

--- a/app/Http/Controllers/Api/OrderController.php
+++ b/app/Http/Controllers/Api/OrderController.php
@@ -142,7 +142,7 @@ class OrderController extends Controller
         $randomApiService = app(\App\Services\RandomApiService::class);
         $user = $order->user;
 
-        if ($user?->sucursal_code === null || $user?->rut === null) {
+        if ($user?->branch_code === null || $user?->rut === null) {
             Log::error(
                 'RandomCredit Error: User missing required attributes',
                 ['user' => $user]
@@ -152,7 +152,7 @@ class OrderController extends Controller
         }
 
         $creditLineResponse = $randomApiService
-            ->getCreditLine($user->rut, $user->sucursal_code);
+            ->getCreditLine($user->rut, $user->branch_code);
 
         $creditLineInfo = $creditLineResponse->json();
 

--- a/app/Http/Requests/AuthRequest.php
+++ b/app/Http/Requests/AuthRequest.php
@@ -30,7 +30,7 @@ class AuthRequest extends FormRequest
     {
 
         return [
-            'rut' => ['required', new ValidateRut()],
+            'rut' => ['required'],
             'password' => [
                 'required',
                 'string',

--- a/app/Jobs/SyncRandomUsers.php
+++ b/app/Jobs/SyncRandomUsers.php
@@ -53,7 +53,7 @@ class SyncRandomUsers implements ShouldQueue
                     $user->business_name = $entidad['SIEN'] ?? '';
                     $user->is_active     = true;
                     $user->phone         = $entidad['FOEN'] ?? null;
-                    $user->sucursal_code = $entidad['SUEN'] ?? null;
+                    $user->branch_code = $entidad['SUEN'] ?? null;
                     // Solo asigna password si es un usuario nuevo
                     if (!$user->exists) {
                         $user->password = bcrypt('password');

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -35,7 +35,7 @@ class User extends Authenticatable
         'last_login',
         'password_changed_at',
         'fcm_token',
-        'sucursal_code',
+        'branch_code',
     ];
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -36,6 +36,8 @@ class User extends Authenticatable
         'password_changed_at',
         'fcm_token',
         'branch_code',
+        'user_code',
+        'random_user_type'
     ];
 
     /**

--- a/database/migrations/2026_04_20_215557_correct_random_erp_fields_in_users_table.php
+++ b/database/migrations/2026_04_20_215557_correct_random_erp_fields_in_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->renameColumn('sucursal_code', 'branch_code');
+            $table->char('random_user_type', 1)
+                ->comment('Random user entity type: "C=Cliente|P=Proveedor|A=Ambos"')
+                ->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->renameColumn('branch_code', 'sucursal_code');
+            $table->dropColumn('random_user_type');
+        });
+    }
+};

--- a/database/migrations/2026_04_20_215557_correct_random_erp_fields_in_users_table.php
+++ b/database/migrations/2026_04_20_215557_correct_random_erp_fields_in_users_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -16,6 +17,21 @@ return new class extends Migration
             $table->char('random_user_type', 1)
                 ->comment('Random user entity type: "C=Cliente|P=Proveedor|A=Ambos"')
                 ->nullable();
+            $table->string('user_code')
+                ->comment('Random user code KOEN')
+                ->nullable();
+        });
+
+        DB::table('users')
+            ->update([
+                'users.user_code' => DB::raw('users.rut')
+            ]);
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('user_code')
+                ->comment('Random user code KOEN')
+                ->nullable(false)
+                ->change();
         });
     }
 
@@ -27,6 +43,7 @@ return new class extends Migration
         Schema::table('users', function (Blueprint $table) {
             $table->renameColumn('branch_code', 'sucursal_code');
             $table->dropColumn('random_user_type');
+            $table->dropColumn('user_code');
         });
     }
 };

--- a/tests/Feature/CreditLineTest.php
+++ b/tests/Feature/CreditLineTest.php
@@ -13,7 +13,7 @@ test('it returns valid credit line successfully', function () {
     /** @var TestCase $this */
 
     /** @var User $user */
-    $user = User::factory()->create(['rut' => '12345678-9', 'sucursal_code' => 'CM']);
+    $user = User::factory()->create(['rut' => '12345678-9', 'branch_code' => 'CM']);
     $user->givePermissionTo('read-own-credit-lines');
     $baseUrl = config('random.url');
     Http::fake([
@@ -46,7 +46,7 @@ test('it returns 500 when Random API returns 200 but with invalid response', fun
     /** @var TestCase $this */
 
     /** @var User $user */
-    $user = User::factory()->create(['rut' => '12345678-9', 'sucursal_code' => 'CM']);
+    $user = User::factory()->create(['rut' => '12345678-9', 'branch_code' => 'CM']);
     $user->givePermissionTo('read-own-credit-lines');
 
     $baseUrl = config('random.url');
@@ -67,7 +67,7 @@ test('it returns 500 when Random API fails with a code different from 404', func
     /** @var TestCase $this */
 
     /** @var User $user */
-    $user = User::factory()->create(['rut' => '12345678-9', 'sucursal_code' => 'CM']);
+    $user = User::factory()->create(['rut' => '12345678-9', 'branch_code' => 'CM']);
     $user->givePermissionTo('read-own-credit-lines');
 
     $baseUrl = config('random.url');
@@ -88,7 +88,7 @@ test('it returns 404 when credit is not found', function () {
     /** @var TestCase $this */
 
     /** @var User $user */
-    $user = User::factory()->create(['rut' => '12345678-9', 'sucursal_code' => 'CM']);
+    $user = User::factory()->create(['rut' => '12345678-9', 'branch_code' => 'CM']);
     $user->givePermissionTo('read-own-credit-lines');
     $baseUrl = config('random.url');
     Http::fake([

--- a/tests/Feature/CreditPaymentTest.php
+++ b/tests/Feature/CreditPaymentTest.php
@@ -20,7 +20,7 @@ test('it can process a credit line payment successfully', function () {
     // $this->artisan('db:seed', ['--class' => 'RolesAndPermissionsSeeder']);
     /** @var TestCase $this */
 
-    $user = User::factory()->create(['rut' => '12345678-9', 'sucursal_code' => 'CM']);
+    $user = User::factory()->create(['rut' => '12345678-9', 'branch_code' => 'CM']);
     if (!$user->hasRole('customer')) {
         $user->assignRole('customer');
     }
@@ -107,7 +107,7 @@ test('it can process a credit line payment successfully', function () {
 test('it handles credit line payment failure correctly', function () {
     /** @var TestCase $this */
 
-    $user = User::factory()->create(['rut' => '12345678-9', 'sucursal_code' => 'CM']);
+    $user = User::factory()->create(['rut' => '12345678-9', 'branch_code' => 'CM']);
     if (!$user->hasRole('customer')) {
         $user->assignRole('customer');
     }
@@ -165,7 +165,7 @@ test('it handles credit line payment failure correctly', function () {
 test('it responds with 500 when Random api returns invalid credit info', function () {
     /** @var TestCase $this */
 
-    $user = User::factory()->create(['rut' => '12345678-9', 'sucursal_code' => 'CM']);
+    $user = User::factory()->create(['rut' => '12345678-9', 'branch_code' => 'CM']);
     if (!$user->hasRole('customer')) {
         $user->assignRole('customer');
     }
@@ -204,7 +204,7 @@ test('it responds with 500 when Random api returns invalid credit info', functio
 test('it fails when the random_credit payment method does not exist in the database', function () {
     /** @var TestCase $this */
 
-    $user = User::factory()->create(['rut' => '12345678-9', 'sucursal_code' => 'CM']);
+    $user = User::factory()->create(['rut' => '12345678-9', 'branch_code' => 'CM']);
     if (!$user->hasRole('customer')) {
         $user->assignRole('customer');
     }
@@ -235,7 +235,7 @@ test('it fails when the random_credit payment method does not exist in the datab
 test('it returns insufficient credit message if order amount exceeds available random credit', function () {
     /** @var TestCase $this */
 
-    $user = User::factory()->create(['rut' => '9876543-2', 'sucursal_code' => 'VALPO']);
+    $user = User::factory()->create(['rut' => '9876543-2', 'branch_code' => 'VALPO']);
     if (!$user->hasRole('customer')) {
         $user->assignRole('customer');
     }
@@ -256,9 +256,9 @@ test('it returns insufficient credit message if order amount exceeds available r
     // Low credit setup
     Http::fake([
         "{$baseUrl}/login" => Http::response(['token' => 'fake_token'], 200),
-        "{$baseUrl}/gestion/credito/resumen/{$user->rut}/{$user->sucursal_code}" => Http::response([
+        "{$baseUrl}/gestion/credito/resumen/{$user->rut}/{$user->branch_code}" => Http::response([
             'KOEN' => $user->rut,
-            'SUEN' => $user->sucursal_code,
+            'SUEN' => $user->branch_code,
             'CRSD' => 2000,     // Total Credit
             'CRSDVU' => 1500,   // Used Credit
             'CRSDVV' => 0,


### PR DESCRIPTION
This pull request introduces several database and code changes to standardize user fields related to the "Random" ERP integration, improve data consistency, and add missing attributes. The main focus is renaming the `sucursal_code` field to `branch_code`, adding new fields to the `users` table, updating model and business logic, and ensuring tests and controllers use the new conventions.

**Database and Model Changes:**

- Renamed the `users` table column `sucursal_code` to `branch_code`, and added two new columns: `random_user_type` (user type from Random ERP) and `user_code` (KOEN code). The migration also ensures `user_code` is always set and backfills it with the user's RUT. (`[database/migrations/2026_04_20_215557_correct_random_erp_fields_in_users_table.phpR1-R49](diffhunk://#diff-df5f6272faf32f03676afcd02a567c4b118edc599c2c8f6061e8a99c8f7e2055R1-R49)`)
- Updated the `User` model's `$fillable` property to include `branch_code`, `user_code`, and `random_user_type`. (`[app/Models/User.phpL38-R40](diffhunk://#diff-37a2d7d879a7de3f7d73b2975cd22be9f41ec10c334a0dda9ad1e869332e4ecbL38-R40)`)

**Business Logic and Command Updates:**

- Added a new artisan command `FixRandomUsers` to ensure user records are correctly synchronized with the latest Random ERP data, handling edge cases like duplicate RUTs or emails. (`[app/Console/Commands/FixRandomUsers.phpR1-R108](diffhunk://#diff-8bf45625e3e9014689ae15d85e9b90dfbe17de863bf82272aec29422b4722192R1-R108)`)
- Updated the `SyncRandomUsers` job to use `branch_code` instead of `sucursal_code` and ensure new fields are properly set. (`[app/Jobs/SyncRandomUsers.phpL56-R56](diffhunk://#diff-8338017a8fc6dc265e87aac8e4f7a619ba31b6881fecc188bc45dc34fda79d76L56-R56)`)

**Controller and Service Adjustments:**

- Updated all usages of `sucursal_code` to `branch_code` in API controllers and services, including credit line and order processing logic. (`[[1]](diffhunk://#diff-569ec277adcba730e1676fa31cacbc5b9fa20589d93638461c67c346e48e8c57L21-R21)`, `[[2]](diffhunk://#diff-1b31a464792b9af06b4db4a316a5a8ca3238c4d30b5b2f564325ae076d672834L145-R145)`, `[[3]](diffhunk://#diff-1b31a464792b9af06b4db4a316a5a8ca3238c4d30b5b2f564325ae076d672834L155-R155)`)

**Testing:**

- Updated all feature tests to use `branch_code` instead of `sucursal_code` for user creation and API endpoint checks. (`[[1]](diffhunk://#diff-9e23cf2742c58e7ce516647c609d9a588b2b7211070b1032034bbaefefd410a5L16-R16)`, `[[2]](diffhunk://#diff-9e23cf2742c58e7ce516647c609d9a588b2b7211070b1032034bbaefefd410a5L49-R49)`, `[[3]](diffhunk://#diff-9e23cf2742c58e7ce516647c609d9a588b2b7211070b1032034bbaefefd410a5L70-R70)`, `[[4]](diffhunk://#diff-9e23cf2742c58e7ce516647c609d9a588b2b7211070b1032034bbaefefd410a5L91-R91)`, `[[5]](diffhunk://#diff-51fc6ca2c10450388530850d658b7fa4ce49b0e1935953e9f772e126f6bd6f27L23-R23)`, `[[6]](diffhunk://#diff-51fc6ca2c10450388530850d658b7fa4ce49b0e1935953e9f772e126f6bd6f27L110-R110)`, `[[7]](diffhunk://#diff-51fc6ca2c10450388530850d658b7fa4ce49b0e1935953e9f772e126f6bd6f27L168-R168)`, `[[8]](diffhunk://#diff-51fc6ca2c10450388530850d658b7fa4ce49b0e1935953e9f772e126f6bd6f27L207-R207)`, `[[9]](diffhunk://#diff-51fc6ca2c10450388530850d658b7fa4ce49b0e1935953e9f772e126f6bd6f27L238-R238)`, `[[10]](diffhunk://#diff-51fc6ca2c10450388530850d658b7fa4ce49b0e1935953e9f772e126f6bd6f27L259-R261)`)

**Validation:**

- Removed the `ValidateRut` custom validation rule from the `rut` field in `AuthRequest`, making it only required (likely to be re-added or replaced in future iterations). (`[app/Http/Requests/AuthRequest.phpL33-R33](diffhunk://#diff-4c56820c101daef03edc487a0dc3cc6fecd131dc23cd95ddbd532b0355878b65L33-R33)`)