### PR TITLE
fix: improve image file retrieval logic in SyncProductImage job

### DIFF
--- a/app/Jobs/SyncProductImage.php
+++ b/app/Jobs/SyncProductImage.php
@@ -66,7 +66,10 @@ class SyncProductImage implements ShouldQueue
 
         // Construir array de filas (sku, image) a partir de los nombres de archivo
         $rows = [];
-        $imageFiles = glob($imagesPath . '/*.{jpg,jpeg,png,gif,webp,bmp,svg}', GLOB_BRACE);
+        $imageFiles = [];
+        foreach (['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp', 'svg'] as $ext) {
+            $imageFiles = array_merge($imageFiles, glob($imagesPath . '/*.' . $ext) ?: []);
+        }
 
         foreach ($imageFiles as $filePath) {
             $imageName = basename($filePath);


### PR DESCRIPTION
This pull request makes a small but important change to the way image files are discovered in the `SyncProductImage` job. The new approach ensures compatibility with systems where the `GLOB_BRACE` flag may not be supported.

- File discovery improvement:
  * Replaces the use of `glob` with the `GLOB_BRACE` flag by iterating over each image file extension and merging the results, making the code more portable and reliable across different environments. (`app/Jobs/SyncProductImage.php`)