### PR TITLE
fix: enhance credit line response, ensure float conversion

### DIFF
--- a/app/Http/Controllers/Api/CreditLineController.php
+++ b/app/Http/Controllers/Api/CreditLineController.php
@@ -23,7 +23,9 @@ class CreditLineController extends Controller
             ->first();
 
         if ($creditLine && $creditLine->is_blocked) {
-            return response()->json($creditLine->state);
+            $payload = $creditLine->state;
+            $payload['status'] = 'blocked';
+            return response()->json($payload);
         }
 
         $response = $this->randomApiService->getCreditLine(

--- a/app/Http/Controllers/Api/OrderController.php
+++ b/app/Http/Controllers/Api/OrderController.php
@@ -281,8 +281,8 @@ class OrderController extends Controller
             $order->randomDocuments()->attach($randomDocument->idmaeedo);
         }
 
-        $localCredit = $creditLineInfo; 
-        $localCredit['CRSDVU'] = bcadd($creditLineInfo['CRSDVU'], $order->amount);
+        $localCredit = $creditLineInfo;
+        $localCredit['CRSDVU'] = floatval(bcadd($creditLineInfo['CRSDVU'], $order->amount));
 
         $creditLine->update([
             'state' => $localCredit,


### PR DESCRIPTION
This pull request introduces small but important improvements to the way credit line state is handled and returned in API responses. The changes ensure that the status of a blocked credit line is explicitly communicated and that credit calculations are consistently cast to the correct data type.

Credit line state handling:

* In `CreditLineController.php`, when a credit line is blocked, the response now explicitly adds a `'status': 'blocked'` field to the returned JSON payload, making the blocked state clearer to API consumers.

Credit calculations:

* In `OrderController.php`, the calculation for the `CRSDVU` field is now explicitly cast to a float after using `bcadd`, ensuring the value is always a float and preventing potential type issues.…sion for payment processing