### PR TITLE
fix: bypass vercel limit for image sync uploads

### DIFF
--- a/app/Http/Controllers/Api/ProductImageSyncController.php
+++ b/app/Http/Controllers/Api/ProductImageSyncController.php
@@ -6,13 +6,53 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\ProductImages\ProductImageSyncStoreRequest;
 use App\Services\ProductImageSyncService;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
 
 class ProductImageSyncController extends Controller
 {
+    private const UPLOAD_SESSION_TTL_SECONDS = 600;
+
+    public function createUploadSession(): JsonResponse
+    {
+        $session = (string) Str::uuid();
+
+        Cache::put(
+            $this->uploadSessionCacheKey($session),
+            true,
+            now()->addSeconds(self::UPLOAD_SESSION_TTL_SECONDS)
+        );
+
+        return response()->json([
+            'upload_session_id' => $session,
+            'expires_in_seconds' => self::UPLOAD_SESSION_TTL_SECONDS,
+        ]);
+    }
+
     public function store(ProductImageSyncStoreRequest $request, ProductImageSyncService $service): JsonResponse
     {
         // Encola el proceso de sincronización
         $service->sync($request->file('sync_file'));
         return response()->json(['message' => 'Sincronización iniciada.']);
+    }
+
+    public function storeUploadSession(
+        ProductImageSyncStoreRequest $request,
+        ProductImageSyncService $service,
+        string $session
+    ): JsonResponse
+    {
+        if (! Cache::pull($this->uploadSessionCacheKey($session))) {
+            return response()->json(['message' => 'Sesión de carga inválida o expirada.'], 404);
+        }
+
+        $service->sync($request->file('sync_file'));
+
+        return response()->json(['message' => 'Sincronización iniciada.']);
+    }
+
+    private function uploadSessionCacheKey(string $session): string
+    {
+        return "product-image-sync-upload:{$session}";
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -48,6 +48,9 @@ Route::prefix('auth')->group(function () {
     });
 });
 
+Route::post('/products/images/sync/upload-session/{session}', [ProductImageSyncController::class, 'storeUploadSession'])
+    ->name('products.image.sync.upload-session.store');
+
 Route::middleware('auth:sanctum')->group(function () {
     Route::get('/profile', [UserController::class, 'profile']);
 
@@ -135,6 +138,10 @@ Route::middleware('auth:sanctum')->group(function () {
         ->middlewareFor('index', 'permission:read-all-subcategories')
         ->middlewareFor('show', 'permission:read-all-subcategories');
 
+
+    Route::post('/products/images/sync/upload-session', [ProductImageSyncController::class, 'createUploadSession'])
+        ->middleware(['permission:sync-product-images'])
+        ->name('products.image.sync.upload-session.create');
 
     Route::post('/products/images/sync', [ProductImageSyncController::class, 'store'])
         ->middleware(['permission:sync-product-images'])
@@ -295,4 +302,3 @@ Route::middleware(['auth:sanctum', 'permission:update-system-config'])
 Route::any('{url}', function () {
     return response()->json(['message' => 'Method Not Allowed.'], 405);
 })->where('url', '.*');
-

--- a/tests/Feature/S3LocalTest.php
+++ b/tests/Feature/S3LocalTest.php
@@ -7,6 +7,7 @@ use App\Models\Product;
 use App\Models\User;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Storage;
 
@@ -95,6 +96,75 @@ describe('Product Image Sync API', function () {
         Storage::disk('s3')->assertExists($zipPath);
 
         Queue::assertPushed(SyncProductImage::class);
+    });
+
+    it('admin can create a temporary upload session', function () {
+        $user = User::factory()->create();
+        $user->givePermissionTo('sync-product-images');
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->post('/api/products/images/sync/upload-session', [], [
+                'Accept' => 'application/json'
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJsonStructure(['upload_session_id', 'expires_in_seconds']);
+
+        $session = $response->json('upload_session_id');
+
+        expect(Cache::get("product-image-sync-upload:{$session}"))->toBeTrue();
+    });
+
+    it('user without permissions cannot create a temporary upload session', function () {
+        $user = User::factory()->create();
+        $user->assignRole('customer');
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->post('/api/products/images/sync/upload-session', [], [
+                'Accept' => 'application/json'
+            ]);
+
+        $response->assertStatus(403);
+    });
+
+    it('can upload ZIP using a valid temporary upload session', function () {
+        Storage::fake('s3');
+        Queue::fake();
+
+        $session = 'test-session';
+        Cache::put("product-image-sync-upload:{$session}", true, now()->addMinutes(10));
+
+        $zipFile = UploadedFile::fake()->create('products.zip', 5000, 'application/zip');
+
+        $response = $this->post("/api/products/images/sync/upload-session/{$session}", [
+            'sync_file' => $zipFile
+        ], [
+            'Accept' => 'application/json'
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJson(['message' => 'Sincronización iniciada.']);
+
+        $zipPath = collect(Storage::disk('s3')->files('product-sync'))
+            ->first(fn($path) => str_ends_with($path, '.zip'));
+
+        expect($zipPath)->not->toBeNull();
+        expect(Cache::get("product-image-sync-upload:{$session}"))->toBeNull();
+
+        Queue::assertPushed(SyncProductImage::class);
+    });
+
+    it('cannot upload ZIP with an expired temporary upload session', function () {
+        $zipFile = UploadedFile::fake()->create('products.zip', 5000, 'application/zip');
+
+        $response = $this->post('/api/products/images/sync/upload-session/expired-session', [
+            'sync_file' => $zipFile
+        ], [
+            'Accept' => 'application/json'
+        ]);
+
+        $response->assertStatus(404)
+            ->assertJson(['message' => 'Sesión de carga inválida o expirada.']);
     });
 
     it('user without permissions cannot upload ZIP for sync', function () {


### PR DESCRIPTION
## Resumen
- Agrega sesiones temporales de carga para sincronización masiva de imágenes.
- Permite que el ZIP se suba directo al backend Laravel, sin pasar el archivo pesado por Vercel.
- Mantiene la autorización inicial con Sanctum y el permiso `sync-product-images`.

## Por Qué
En QA el frontend está desplegado en Vercel. El flujo anterior enviaba el ZIP a una API Route de Next (`/api/admin/products/sync-images`) y esa Function reenviaba el mismo archivo al backend Laravel.

Ese diseño funciona en local porque `next dev`/Node no aplica el mismo límite duro de Vercel. En Vercel, en cambio, las Functions tienen un límite fijo de payload de aproximadamente 4.5 MB. Por eso un ZIP de 8.4 MB falla con HTTP 413 antes de que Laravel pueda validar o procesar el archivo.

No alcanza con subir `bodySizeLimit` en Next, porque ese setting no elimina el límite de entrada de Vercel Functions. Mientras el archivo pase por una Function, el límite sigue existiendo.

## Por Qué Sesiones Temporales
La forma correcta de evitar el 413 es sacar a Vercel del camino del archivo pesado:

```txt
Antes:
Browser -> Vercel Function con ZIP grande -> Laravel

Ahora:
Browser -> Vercel Function request chica -> Laravel crea sesión temporal
Browser -> Laravel directo con ZIP grande usando esa sesión
```

La sesión temporal existe para resolver el problema sin debilitar seguridad:

- El navegador no necesita leer ni exponer el token real del usuario.
- La creación de sesión sigue protegida por `auth:sanctum` y `permission:sync-product-images`.
- El endpoint directo de upload no queda abierto libremente: requiere un identificador de sesión válido.
- La sesión expira en 10 minutos.
- La sesión se consume con `Cache::pull`, por lo que es de un solo uso.
- La validación existente del ZIP sigue pasando por `ProductImageSyncStoreRequest`.
- El procesamiento existente se mantiene usando `ProductImageSyncService`.

Este enfoque permite uploads mayores a 4.5 MB sin pasar el archivo por Vercel y sin mover credenciales sensibles al cliente.

## Cambios
| Archivo | Cambio |
| --- | --- |
| `app/Http/Controllers/Api/ProductImageSyncController.php` | Crea sesiones temporales, consume sesiones válidas de un solo uso y reutiliza el servicio existente para procesar el ZIP. |
| `routes/api.php` | Agrega una ruta autenticada para crear la sesión y una ruta directa para subir usando la sesión temporal. |
| `tests/Feature/S3LocalTest.php` | Cubre creación de sesión, bloqueo por permisos, upload con sesión válida y rechazo de sesión expirada/inválida. |

## Verificación
- No se corrió build por regla del proyecto.
- No pude correr `php artisan test tests/Feature/S3LocalTest.php` localmente porque este shell no tiene `php` disponible.