### PR TITLE
fix: agrega 'tipr=FPN' como parametro para filtrar productos normales

### DIFF
--- a/app/Services/RandomApiService.php
+++ b/app/Services/RandomApiService.php
@@ -176,7 +176,7 @@ class RandomApiService
         if (!empty($pfpr)) $params['pfpr'] = $pfpr;
         if (!empty($hfpr)) $params['hfpr'] = $hfpr;
 
-        return $this->makeRequest('get', '/productos', $params);
+        return $this->makeRequest('get', '/productos?tipr=FPN', $params);
     }
 
     public function getCategories()


### PR DESCRIPTION
Agrega el parametro segun la documentacion para evitar productos que no son para venta, segun la documentacion: https://documenter.getpostman.com/view/467703/Tz5v3bJp#3b3b5d8c-a255-43eb-bb4d-70cc15aac06a

<img width="1150" height="368" alt="image" src="https://github.com/user-attachments/assets/1411342e-4f5a-4471-8874-93c816037c11" />
