### PR TITLE
fix: desactiva productos que no existen en el ERP

### DIFF
--- a/app/Jobs/SyncRandomProducts.php
+++ b/app/Jobs/SyncRandomProducts.php
@@ -37,6 +37,7 @@ class SyncRandomProducts implements ShouldQueue
         Log::info('SyncRandomProducts started');
         try {
             $products = $randomApi->getProducts($this->tipr);
+            $syncedProductIds = [];
 
             foreach ($products['data'] as $product) {
 
@@ -50,7 +51,7 @@ class SyncRandomProducts implements ShouldQueue
                 if(!empty($product['MRPR'])){
                     $brand = Brand::where('random_erp_code', $product['MRPR'])->first();
                 }
-    
+
                 $data = [
                     'random_product_id' => $product['KOPR'],
                     'sku' => $product['KOPR'],
@@ -61,13 +62,20 @@ class SyncRandomProducts implements ShouldQueue
                     'subcategory_id' => $subcategory ? $subcategory->id : null,
                     'status' => true,
                 ];
-                
+
                 //Update or create product
                 Product::updateOrCreate(
                     ['random_product_id' => $product['KOPR']], $data
                 );
+
+                $syncedProductIds[] = $product['KOPR'];
             }
-            
+
+            // Deactivate products that are no longer in the API
+            Product::whereNotIn('random_product_id', $syncedProductIds)
+                ->where('status', true)
+                ->update(['status' => false]);
+
             Log::info('SyncRandomProducts finished');
         } catch (\Exception $e) {
             Log::error('Error sincronizando productos: ' . $e->getMessage());

--- a/tests/Feature/SyncProductTest.php
+++ b/tests/Feature/SyncProductTest.php
@@ -268,11 +268,12 @@ describe('Product Sync Basic', function () {
     });
 
     test('el servicio RandomApiService obtiene token correctamente', function () {
+        $baseUrl = config('random.url');
         Http::fake([
-            'http://seguimiento.random.cl:3003/login' => Http::response([
+            $baseUrl . '/login' => Http::response([
                 'token' => 'fake-jwt-token'
             ], 200),
-            'http://seguimiento.random.cl:3003/productos*' => Http::response([
+            $baseUrl . '/productos*' => Http::response([
                 'data' => []
             ], 200)
         ]);
@@ -283,19 +284,20 @@ describe('Product Sync Basic', function () {
         expect($result)->toBeArray();
         expect($result)->toHaveKey('data');
 
-        Http::assertSent(function ($request) {
-            return $request->url() === 'http://seguimiento.random.cl:3003/login' &&
+        Http::assertSent(function ($request) use ($baseUrl) {
+            return $request->url() === $baseUrl . '/login' &&
                    $request['username'] === 'demo@random.cl' &&
                    $request['password'] === 'd3m0r4nd0m3RP';
         });
     });
 
     test('el servicio maneja tokens expirados correctamente', function () {
+        $baseUrl = config('random.url');
         Http::fake([
-            'http://seguimiento.random.cl:3003/login' => Http::response([
+            $baseUrl . '/login' => Http::response([
                 'token' => 'fake-jwt-token'
             ], 200),
-            'http://seguimiento.random.cl:3003/productos*' => Http::sequence()
+            $baseUrl . '/productos*' => Http::sequence()
                 ->push(['message' => 'jwt expired'], 401)
                 ->push(['data' => []], 200)
         ]);
@@ -401,6 +403,50 @@ describe('Product Sync Basic', function () {
         expect($product->category_id)->toBeNull();
         expect($product->subcategory_id)->toBeNull();
         expect($product->name)->toBe('Producto Sin Categoría');
+    });
+
+    test('los productos que ya no vienen en la API se desactivan', function () {
+        // 1. Crear dos productos iniciales activos
+        Product::create([
+            'random_product_id' => 'PROD_STAY',
+            'sku' => 'PROD_STAY',
+            'name' => 'Producto que sigue en API',
+            'status' => true
+        ]);
+
+        Product::create([
+            'random_product_id' => 'PROD_GONE',
+            'sku' => 'PROD_GONE',
+            'name' => 'Producto que desaparece',
+            'status' => true
+        ]);
+
+        // 2. Simular que la API SOLO devuelve el primero
+        $mockApiService = Mockery::mock(RandomApiService::class);
+        $apiResponse = [
+            'data' => [
+                [
+                    'KOPR' => 'PROD_STAY',
+                    'NOKOPR' => 'Producto que sigue en API',
+                    'FMPR' => '',
+                    'PFPR' => ''
+                ]
+            ]
+        ];
+
+        $mockApiService->shouldReceive('getProducts')
+            ->once()
+            ->andReturn($apiResponse);
+
+        Log::shouldReceive('info')->twice();
+
+        // 3. Ejecutar el Job
+        $job = new SyncRandomProducts();
+        $job->handle($mockApiService);
+
+        // 4. Verificar resultados
+        expect(Product::where('random_product_id', 'PROD_STAY')->first()->status)->toBe(true);
+        expect(Product::where('random_product_id', 'PROD_GONE')->first()->status)->toBe(false);
     });
 
 });


### PR DESCRIPTION
Esta solicitud de extracción actualiza la lógica de sincronización de productos en `SyncRandomProducts` para garantizar que los productos que ya no están presentes en la API externa se desactiven en la base de datos local. Esto mejora la coherencia de los datos entre la API externa y los registros de productos locales.

**Mejoras en la sincronización de productos:**

* Durante el proceso de sincronización, se registran los IDs de los productos recibidos desde la API en un array `$syncedProductIds`.
* Después de la sincronización, desactiva cualquier registro local de `Product` (establece el `status` como `false`) que no esté presente en la respuesta más reciente de la API, asegurando que los productos obsoletos se marquen correctamente como inactivos.