### PR TITLE
feat(siteinfo): support banner slides

### DIFF
--- a/app/Http/Controllers/Api/SiteinfoController.php
+++ b/app/Http/Controllers/Api/SiteinfoController.php
@@ -157,9 +157,8 @@ class SiteinfoController extends Controller
                 "content" => ""
             ],
             "banner" => [
-                "desktop_image" => "",
-                "mobile_image" => "",
-                "enabled" => false
+                "enabled" => false,
+                "slides" => []
             ],
             "modal" => [
                 "image" => "",
@@ -182,6 +181,15 @@ class SiteinfoController extends Controller
             'banner_desktop_image' => 'nullable|image',
             'banner_mobile_image' => 'nullable|image',
             'banner_enabled' => 'required|boolean',
+            'banner_slides' => 'nullable|array',
+            'banner_slides.*.id' => 'nullable|string',
+            'banner_slides.*.desktop_image' => 'nullable|image',
+            'banner_slides.*.mobile_image' => 'nullable|image',
+            'banner_slides.*.existing_desktop_image' => 'nullable|string',
+            'banner_slides.*.existing_mobile_image' => 'nullable|string',
+            'banner_slides.*.alt' => 'nullable|string',
+            'banner_slides.*.order' => 'nullable|integer',
+            'banner_slides.*.enabled' => 'nullable|boolean',
             'modal_image' => 'nullable|image',
             'modal_enabled' => 'required|boolean',
             'message_enabled' => 'required|boolean',
@@ -190,11 +198,7 @@ class SiteinfoController extends Controller
         $customerMessage = Siteinfo::where('key', 'customer_message')->first();
         $oldValue = $customerMessage ? $customerMessage->value : [];
 
-        $bannerDesktopImage = $this->saveImage($request, 'banner_desktop_image', 'customer-message/banner-desktop')
-            ?? ($oldValue['banner']['desktop_image'] ?? '');
-
-        $bannerMobileImage = $this->saveImage($request, 'banner_mobile_image', 'customer-message/banner-mobile')
-            ?? ($oldValue['banner']['mobile_image'] ?? '');
+        $bannerSlides = $this->buildBannerSlides($request, $oldValue['banner']['slides'] ?? []);
 
         $modalImage = $this->saveImage($request, 'modal_image', 'customer-message/modal')
             ?? ($oldValue['modal']['image'] ?? '');
@@ -205,9 +209,8 @@ class SiteinfoController extends Controller
                 'content' => $data['header_content'] ?? '',
             ],
             'banner' => [
-                'desktop_image' => $bannerDesktopImage,
-                'mobile_image' => $bannerMobileImage,
                 'enabled' => (bool)$data['banner_enabled'],
+                'slides' => $bannerSlides,
             ],
             'modal' => [
                 'image' => $modalImage,
@@ -229,6 +232,55 @@ class SiteinfoController extends Controller
         );
 
         return response()->json(['message' => 'Mensaje de bienvenida actualizado correctamente.']);
+    }
+
+    private function buildBannerSlides(Request $request, array $oldSlides): array
+    {
+        if (!$request->has('banner_slides')) {
+            $desktopImage = $this->saveImage($request, 'banner_desktop_image', 'customer-message/banner-desktop')
+                ?? ($oldSlides[0]['desktop_image'] ?? '');
+
+            $mobileImage = $this->saveImage($request, 'banner_mobile_image', 'customer-message/banner-mobile')
+                ?? ($oldSlides[0]['mobile_image'] ?? '');
+
+            if (!$desktopImage && !$mobileImage) {
+                return [];
+            }
+
+            return [[
+                'id' => $oldSlides[0]['id'] ?? uniqid('banner_', true),
+                'desktop_image' => $desktopImage,
+                'mobile_image' => $mobileImage,
+                'alt' => $oldSlides[0]['alt'] ?? 'Banner principal',
+                'order' => 1,
+                'enabled' => true,
+            ]];
+        }
+
+        $slides = [];
+
+        foreach ($request->input('banner_slides', []) as $index => $slide) {
+            $desktopImage = $this->saveImage($request, "banner_slides.$index.desktop_image", 'customer-message/banner-desktop')
+                ?? ($slide['existing_desktop_image'] ?? '');
+
+            $mobileImage = $this->saveImage($request, "banner_slides.$index.mobile_image", 'customer-message/banner-mobile')
+                ?? ($slide['existing_mobile_image'] ?? '');
+
+            if (!$desktopImage && !$mobileImage) {
+                continue;
+            }
+
+            $slides[] = [
+                'id' => $slide['id'] ?? uniqid('banner_', true),
+                'desktop_image' => $desktopImage,
+                'mobile_image' => $mobileImage,
+                'alt' => $slide['alt'] ?? 'Banner principal',
+                'order' => (int)($slide['order'] ?? $index + 1),
+                'enabled' => array_key_exists('enabled', $slide) ? (bool)$slide['enabled'] : true,
+            ];
+        }
+
+        return collect($slides)->sortBy('order')->values()->all();
     }
 
     private function saveImage(Request $request, string $requestFileName, string $s3path)

--- a/database/migrations/2026_06_16_210000_migrate_customer_message_banner_to_slides.php
+++ b/database/migrations/2026_06_16_210000_migrate_customer_message_banner_to_slides.php
@@ -1,0 +1,64 @@
+<?php
+
+use App\Models\Siteinfo;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $record = Siteinfo::where('key', 'customer_message')->first();
+
+        if (!$record || !$record->value) {
+            return;
+        }
+
+        $value = $record->value;
+        $banner = $value['banner'] ?? [];
+
+        if (isset($banner['slides']) && is_array($banner['slides'])) {
+            return;
+        }
+
+        $slides = [];
+
+        if (!empty($banner['desktop_image']) || !empty($banner['mobile_image'])) {
+            $slides[] = [
+                'id' => 'legacy-banner',
+                'desktop_image' => $banner['desktop_image'] ?? '',
+                'mobile_image' => $banner['mobile_image'] ?? '',
+                'alt' => 'Banner principal',
+                'order' => 1,
+                'enabled' => true,
+            ];
+        }
+
+        $value['banner'] = [
+            'enabled' => (bool)($banner['enabled'] ?? false),
+            'slides' => $slides,
+        ];
+
+        $record->update(['value' => $value]);
+    }
+
+    public function down(): void
+    {
+        $record = Siteinfo::where('key', 'customer_message')->first();
+
+        if (!$record || !$record->value) {
+            return;
+        }
+
+        $value = $record->value;
+        $banner = $value['banner'] ?? [];
+        $firstSlide = $banner['slides'][0] ?? [];
+
+        $value['banner'] = [
+            'desktop_image' => $firstSlide['desktop_image'] ?? '',
+            'mobile_image' => $firstSlide['mobile_image'] ?? '',
+            'enabled' => (bool)($banner['enabled'] ?? false),
+        ];
+
+        $record->update(['value' => $value]);
+    }
+};

--- a/tests/Feature/SiteinfoTest.php
+++ b/tests/Feature/SiteinfoTest.php
@@ -6,6 +6,7 @@ use App\Models\Siteinfo;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Storage;
 
 uses(RefreshDatabase::class);
@@ -166,9 +167,37 @@ describe('Customer Message API', function () {
                 ->assertOk()
                 ->assertJsonStructure([
                     'header' => ['color', 'content'],
-                    'banner' => ['desktop_image', 'mobile_image', 'enabled'],
+                    'banner' => ['enabled', 'slides'],
                     'modal' => ['image', 'enabled']
                 ]);
+        });
+
+        it('migrates legacy banner structure to slides', function () {
+            Siteinfo::create([
+                'key' => 'customer_message',
+                'value' => [
+                    'header' => ['color' => '#fff', 'content' => 'Hola'],
+                    'banner' => [
+                        'desktop_image' => 'https://example.test/desktop.jpg',
+                        'mobile_image' => 'https://example.test/mobile.jpg',
+                        'enabled' => true,
+                    ],
+                    'modal' => ['image' => '', 'enabled' => false],
+                ],
+            ]);
+
+            Artisan::call('migrate', [
+                '--path' => 'database/migrations/2026_06_16_210000_migrate_customer_message_banner_to_slides.php',
+                '--realpath' => false,
+                '--force' => true,
+            ]);
+
+            $record = Siteinfo::where('key', 'customer_message')->first();
+
+            expect($record->value['banner']['enabled'])->toBeTrue();
+            expect($record->value['banner']['slides'][0]['desktop_image'])->toBe('https://example.test/desktop.jpg');
+            expect($record->value['banner']['slides'][0]['mobile_image'])->toBe('https://example.test/mobile.jpg');
+            expect($record->value['banner']['slides'][0]['enabled'])->toBeTrue();
         });
     });
 
@@ -230,9 +259,52 @@ describe('Customer Message API', function () {
             expect($record->value['modal']['enabled'])->toBeBool();
             expect($record->value['message']['enabled'])->toBeBool();
             
-            expect($record->value['banner']['desktop_image'])->toStartWith('http');
-            expect($record->value['banner']['mobile_image'])->toStartWith('http');
+            expect($record->value['banner']['slides'][0]['desktop_image'])->toStartWith('http');
+            expect($record->value['banner']['slides'][0]['mobile_image'])->toStartWith('http');
             expect($record->value['modal']['image'])->toStartWith('http');
+        });
+
+        it('stores multiple banner slides and preserves existing images', function () {
+            $user = User::factory()->create();
+            $user->givePermissionTo('update-content-settings');
+
+            $payload = [
+                'header_color' => '#fff',
+                'header_content' => '<h1>Hola</h1>',
+                'banner_enabled' => true,
+                'modal_enabled' => false,
+                'message_enabled' => true,
+                'banner_slides' => [
+                    [
+                        'id' => 'slide-a',
+                        'existing_desktop_image' => 'https://example.test/a-desktop.jpg',
+                        'existing_mobile_image' => 'https://example.test/a-mobile.jpg',
+                        'alt' => 'Slide A',
+                        'order' => 2,
+                        'enabled' => true,
+                    ],
+                    [
+                        'id' => 'slide-b',
+                        'existing_desktop_image' => 'https://example.test/b-desktop.jpg',
+                        'existing_mobile_image' => 'https://example.test/b-mobile.jpg',
+                        'alt' => 'Slide B',
+                        'order' => 1,
+                        'enabled' => false,
+                    ],
+                ],
+            ];
+
+            $this->actingAs($user, 'sanctum')
+                ->putJson(route('siteinfo.customer-message.update'), $payload)
+                ->assertOk();
+
+            $record = Siteinfo::where('key', 'customer_message')->first();
+
+            expect($record->value['banner']['slides'])->toHaveCount(2);
+            expect($record->value['banner']['slides'][0]['id'])->toBe('slide-b');
+            expect($record->value['banner']['slides'][0]['desktop_image'])->toBe('https://example.test/b-desktop.jpg');
+            expect($record->value['banner']['slides'][1]['id'])->toBe('slide-a');
+            expect($record->value['banner']['slides'][1]['enabled'])->toBeTrue();
         });
 
         it('allows superadmin to update customer message without images', function () {
@@ -261,8 +333,7 @@ describe('Customer Message API', function () {
             expect($record->value['message']['enabled'])->toBeBool();
 
             // Verifica que las imágenes sean string vacíos (no concatenados)
-            expect($record->value['banner']['desktop_image'])->toBe('');
-            expect($record->value['banner']['mobile_image'])->toBe('');
+            expect($record->value['banner']['slides'])->toBe([]);
             expect($record->value['modal']['image'])->toBe('');
         });
     });


### PR DESCRIPTION
## Summary
- Adds JSON-backed banner slides to customer message settings.
- Migrates the existing legacy desktop/mobile banner JSON into the new slides shape.
- Updates Siteinfo feature tests for the new contract, migration, and image preservation flow.

## Changes
| File | Change |
|------|--------|
| `app/Http/Controllers/Api/SiteinfoController.php` | Accepts `banner_slides`, preserves existing image URLs, and stores ordered slides. |
| `database/migrations/2026_06_16_210000_migrate_customer_message_banner_to_slides.php` | Migrates existing `customer_message.banner.desktop_image/mobile_image` into `banner.slides[0]`; rollback restores the first slide to legacy fields. |
| `tests/Feature/SiteinfoTest.php` | Updates expectations and adds coverage for migration and multiple slide persistence. |

## Test Plan
- [ ] `php artisan test tests/Feature/SiteinfoTest.php` attempted in Docker, but exceeded 300s timeout.

## Notes
- Database schema is unchanged; this is a data migration for the JSON stored in `siteinfo.value`.