### PR TITLE
fix: round webpay order totals

### DIFF
--- a/app/Http/Controllers/Api/OrderController.php
+++ b/app/Http/Controllers/Api/OrderController.php
@@ -79,7 +79,8 @@ class OrderController extends Controller
                 return $price->price * $cart->quantity;
             });
 
-            $shippingCost = $subtotal >= 70000 ? 0 : config('random.fixed_shipping_cost');
+            $subtotal = (int) round($subtotal);
+            $shippingCost = $subtotal >= 70000 ? 0 : (int) config('random.fixed_shipping_cost');
             $total = $subtotal + $shippingCost;
 
             $user = User::find(Auth::user()->id);

--- a/database/factories/OrderFactory.php
+++ b/database/factories/OrderFactory.php
@@ -26,7 +26,7 @@ class OrderFactory extends Factory
      */
     public function definition(): array
     {
-        $subtotal = fake()->randomFloat(2, 1000, 100000);
+        $subtotal = fake()->numberBetween(1000, 100000);
 
         //Factory 10 Region and Municipality
         $regions = Region::factory()->count(10)->create();
@@ -48,7 +48,7 @@ class OrderFactory extends Factory
             'billing_address_details' => fake()->address(),
         ];
         
-        $shippingCost = $subtotal >= 70000 ? 0 : config('random.fixed_shipping_cost');
+        $shippingCost = $subtotal >= 70000 ? 0 : (int) config('random.fixed_shipping_cost');
 
         return [
             'user_id' => User::factory(),

--- a/tests/Feature/OrderTest.php
+++ b/tests/Feature/OrderTest.php
@@ -333,6 +333,40 @@ describe('OrderController', function () {
             expect($order->amount)->toBe(6440.0);
         });
 
+        test('rounds cart subtotal to whole pesos before sending payment amount', function () {
+            /** @var TestCase $this */
+
+            // Arrange
+            createProductCart(1152.5, 3);
+            createProductCart(100.4, 1);
+            $address = Address::factory()->create([
+                'user_id' => $this->user->id
+            ]);
+
+            $this->mock(WebpayService::class, function ($mock) {
+                $mock->shouldReceive('createTransaction')
+                    ->once()
+                    ->withArgs(function (Order $order) {
+                        return $order->subtotal === 3558.0
+                            && $order->shipping_cost === 5990.0
+                            && $order->amount === 9548.0;
+                    })
+                    ->andReturn([
+                        'url' => 'https://webpay.test/init',
+                        'token' => 'test-token-123'
+                    ]);
+            });
+
+            // Act
+            $response = $this->postJson(route('orders.pay'), [
+                'address_id' => $address->id,
+                'payment_method' => 'transbank'
+            ]);
+
+            // Assert
+            $response->assertOk();
+        });
+
         test('includes user and address metadata in order', function () {
             /** @var TestCase $this */
 


### PR DESCRIPTION
Redondea el subtotal total del carrito a pesos enteros antes de calcular envío y total.