### PR TITLE
Typos search

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,12 @@ RANDOM_ERP_WAREHOUSE_CODE=BEC
 RANDOM_ERP_BUSINESS_FUNCTIONARY=A02
 RANDOM_ERP_DOCUMENTS_DRY_RUN=true
 
+# Email recipient for warehouse notifications on completed orders
+WAREHOUSE_EMAIL_RECIPIENT=warehouse@socomarca.cl
+
+# Site logo URL used in transactional emails
+SITE_LOGO_URL=https://socomarca-frontend.vercel.app/assets/global/logo.png
+
 # Random API Mocking for QA and testing purposes
 RANDOM_MOCK_DOCS=true
 RANDOM_MOCK_DOCS_RESPONSE_BAD=true

--- a/.env.testing.example
+++ b/.env.testing.example
@@ -69,3 +69,9 @@ VITE_APP_NAME="${APP_NAME}"
 SCOUT_DRIVER=meilisearch
 MEILISEARCH_HOST=http://meilisearch:7700
 MEILISEARCH_KEY=masterKey
+
+# Email recipient for warehouse notifications on completed orders
+WAREHOUSE_EMAIL_RECIPIENT=warehouse@example.com
+
+# Site logo URL used in transactional emails
+SITE_LOGO_URL=https://socomarca-frontend.vercel.app/assets/global/logo.png

--- a/app/Events/OrderCompleted.php
+++ b/app/Events/OrderCompleted.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Order;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class OrderCompleted
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public Order $order
+    )
+    {
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, \Illuminate\Broadcasting\Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/OrderController.php
+++ b/app/Http/Controllers/Api/OrderController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Enums\BranchType;
 use App\Enums\PaymentDocumentType;
+use App\Events\OrderCompleted;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Orders\PayOrderRequest;
 use App\Http\Resources\Orders\OrderCollection;
@@ -326,7 +327,7 @@ class OrderController extends Controller
             'paid_at' => now(),
             'generate_random_doc_type' => $generateRandomDocType,
         ]);
-
+        OrderCompleted::dispatch($order);
         $localCredit = $creditLineInfo;
         $localCredit['CRSDVU'] = floatval(bcadd($creditLineInfo['CRSDVU'], $order->amount));
 

--- a/app/Http/Controllers/Api/WebpayController.php
+++ b/app/Http/Controllers/Api/WebpayController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Enums\PaymentDocumentType;
+use App\Events\OrderCompleted;
 use App\Http\Controllers\Controller;
 use App\Models\Order;
 use App\Models\Payment;
@@ -49,6 +50,9 @@ class WebpayController extends Controller
                     $order->status = $result['status'] === 'AUTHORIZED' ? 'completed' : 'failed';
                     $order->save();
 
+                    if ($order->status === 'completed') {
+                        OrderCompleted::dispatch($order);
+                    }
                     $payment->response_status = $result['status'];
                     $payment->response_message = json_encode($result);
                     $payment->auth_code = $result['authorization_code'] ?? null;

--- a/app/Listeners/SendOrderCompletedEmail.php
+++ b/app/Listeners/SendOrderCompletedEmail.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\OrderCompleted;
+use App\Mail\OrderCompletedMail;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+
+class SendOrderCompletedEmail implements ShouldQueue
+{
+    use InteractsWithQueue;
+
+    /**
+     * Create the event listener.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     */
+    public function handle(OrderCompleted $event): void
+    {
+        $recipient = config('random.warehouse_email_recipient');
+
+        if (empty($recipient)) {
+            Log::warning('SendOrderCompletedEmail: WAREHOUSE_EMAIL_RECIPIENT is not configured, skipping email send.', [
+                'order_id' => $event->order->id,
+            ]);
+            return;
+        }
+
+        $event->order->loadMissing(['user', 'orderDetails.product', 'branch', 'payments.paymentMethod']);
+
+        Mail::to($recipient)->send(new OrderCompletedMail($event->order));
+    }
+}

--- a/app/Mail/OrderCompletedMail.php
+++ b/app/Mail/OrderCompletedMail.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Order;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class OrderCompletedMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public Order $order
+    ) {
+        $this->order->loadMissing(['user', 'orderDetails.product', 'branch', 'payments.paymentMethod']);
+    }
+
+    public function envelope(): Envelope
+    {
+        $customerName = $this->order->user?->name ?? 'Cliente';
+
+        return new Envelope(
+            subject: "{$customerName} ha registrado la compra N°{$this->order->id} en SOCOMARCA",
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.order-completed',
+            with: [
+                'order' => $this->order,
+            ],
+        );
+    }
+}

--- a/app/Services/Data/ProductQueryService.php
+++ b/app/Services/Data/ProductQueryService.php
@@ -247,13 +247,13 @@ class ProductQueryService
         $searchTerm = $this->filters['name'];
 
         $query->where(function (Builder $q) use ($searchTerm) {
-            $q->whereRaw('similarity(name, ?) > 0.3', [$searchTerm])
+            $q->whereRaw('word_similarity(?, name) > 0.5', [$searchTerm])
                 ->orWhere('name', 'ILIKE', "%{$searchTerm}%")
                 ->orWhere('sku', 'ILIKE', "%{$searchTerm}%");
         });
 
         if (! isset($this->filters['sort'])) {
-            $query->orderByRaw('similarity(name, ?) DESC', [$searchTerm]);
+            $query->orderByRaw('word_similarity(?, name) DESC', [$searchTerm]);
         }
     }
 

--- a/config/random.php
+++ b/config/random.php
@@ -29,4 +29,6 @@ return [
     'documents' => [
         'dry_run' => env('RANDOM_ERP_DOCUMENTS_DRY_RUN', false),
     ],
+    'warehouse_email_recipient' => env('WAREHOUSE_EMAIL_RECIPIENT', 'warehouse@socomarca.cl'),
+    'site_logo_url' => env('SITE_LOGO_URL', 'https://socomarca-frontend.vercel.app/assets/global/logo.png'),
 ];

--- a/resources/views/emails/order-completed.blade.php
+++ b/resources/views/emails/order-completed.blade.php
@@ -1,0 +1,382 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Nueva compra registrada</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #ffffff;
+            margin: 0;
+            padding: 0;
+            color: #333333;
+        }
+        .container {
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        .header {
+            text-align: center;
+            padding: 24px 0 16px;
+        }
+        .header img {
+            max-width: 220px;
+        }
+        .divider {
+            height: 4px;
+            background-color: #6cb409;
+            margin: 16px 0 32px;
+        }
+        .cart-icon-wrapper {
+            text-align: center;
+            margin: 24px 0;
+        }
+        .cart-icon {
+            display: inline-block;
+            width: 80px;
+            height: 80px;
+            line-height: 80px;
+            border-radius: 50%;
+            background-color: #6cb409;
+            color: #ffffff;
+            font-size: 36px;
+        }
+        .intro {
+            text-align: center;
+            font-size: 18px;
+            line-height: 1.5;
+            margin: 24px 0 12px;
+        }
+        .order-summary {
+            text-align: center;
+            font-size: 18px;
+            margin-bottom: 32px;
+        }
+        .order-summary strong {
+            color: #111111;
+        }
+        h3 {
+            font-size: 16px;
+            margin: 0 0 8px 0;
+            color: #111111;
+        }
+        .section-title {
+            font-size: 18px;
+            font-weight: bold;
+            margin: 32px 0 16px;
+            color: #111111;
+        }
+        .product-row {
+            display: flex;
+            align-items: flex-start;
+            padding: 16px 0;
+            border-bottom: 1px solid #e5e5e5;
+        }
+        .product-image {
+            flex: 0 0 96px;
+            width: 96px;
+            height: 96px;
+            background-color: #f0f0f0;
+            margin-right: 16px;
+            text-align: center;
+            line-height: 96px;
+            color: #999999;
+            font-size: 12px;
+        }
+        .product-image img {
+            max-width: 100%;
+            max-height: 100%;
+        }
+        .product-info {
+            flex: 1 1 auto;
+        }
+        .product-name {
+            font-size: 16px;
+            font-weight: bold;
+            margin-bottom: 4px;
+            color: #111111;
+        }
+        .product-meta {
+            font-size: 14px;
+            color: #555555;
+        }
+        .product-price {
+            flex: 0 0 auto;
+            font-size: 16px;
+            font-weight: bold;
+            color: #111111;
+            align-self: center;
+        }
+        .meta-totals-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 24px;
+        }
+        .meta-totals-table > tbody > tr > td {
+            vertical-align: top;
+            padding: 8px 0;
+        }
+        .meta-col {
+            width: 50%;
+            padding-right: 24px !important;
+        }
+        .totals-col {
+            width: 50%;
+        }
+        .meta-block {
+            margin-bottom: 16px;
+        }
+        .meta-block .meta-label {
+            font-size: 18px;
+            font-weight: bold;
+            color: #111111;
+            margin: 0 0 4px 0;
+        }
+        .meta-block .meta-value {
+            font-size: 14px;
+            color: #555555;
+            margin: 0;
+        }
+        .totals-table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        .totals-table td {
+            padding: 6px 0;
+            font-size: 14px;
+            color: #555555;
+        }
+        .totals-table .label-col {
+            text-align: left;
+        }
+        .totals-table .amount-col {
+            text-align: right;
+            color: #111111;
+        }
+        .totals-table tr.total td {
+            font-size: 18px;
+            font-weight: bold;
+            color: #111111;
+            padding-top: 12px;
+        }
+        .addresses-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 16px;
+        }
+        .addresses-table th {
+            text-align: left;
+            font-size: 16px;
+            font-weight: bold;
+            padding: 8px 0;
+            color: #111111;
+        }
+        .addresses-table td {
+            vertical-align: top;
+            font-size: 14px;
+            line-height: 1.5;
+            color: #333333;
+            padding: 4px 12px 0 0;
+            width: 50%;
+        }
+        .note-block {
+            margin: 24px 0;
+            font-size: 14px;
+            color: #333333;
+        }
+        .footer {
+            background-color: #6cb409;
+            color: #ffffff;
+            text-align: center;
+            padding: 32px 20px;
+            margin-top: 32px;
+        }
+        .footer .tagline {
+            font-size: 18px;
+            font-weight: bold;
+            letter-spacing: 1px;
+            margin-bottom: 20px;
+        }
+        .social {
+            margin: 16px 0;
+        }
+        .social a {
+            display: inline-block;
+            width: 32px;
+            height: 32px;
+            line-height: 32px;
+            border: 2px solid #ffffff;
+            border-radius: 50%;
+            color: #ffffff;
+            margin: 0 6px;
+            text-decoration: none;
+            font-size: 14px;
+        }
+        .footer .sent-by {
+            font-size: 14px;
+            margin-top: 16px;
+        }
+        .footer .contact {
+            font-size: 13px;
+            margin-top: 4px;
+            opacity: 0.95;
+        }
+    </style>
+</head>
+<body>
+    @php
+        $customer = $order->user;
+        $customerName = $customer?->name ?? 'Cliente';
+        $billingAddress = $order->order_meta['address'] ?? [];
+        $shippingAddress = $order->order_meta['address'] ?? [];
+        $payment = $order->payments->first();
+        $paymentMethodLabel = $payment?->paymentMethod?->name ?? 'No especificado';
+        $shippingMethodLabel = ($order->shipping_cost > 0) ? 'Despacho a domicilio' : 'Retiro en tienda';
+        $subtotal = (int) $order->subtotal;
+        $shippingCost = (int) $order->shipping_cost;
+        $discount = 0;
+        $refund = 0;
+        $total = (int) $order->amount;
+        $orderDate = optional($order->created_at)->format('d/m/Y H:i');
+    @endphp
+
+    <div class="container">
+        <div class="header">
+            <img src="{{ config('random.site_logo_url') }}" alt="Socomarca Compra Rápida" />
+        </div>
+        <div class="divider"></div>
+
+        <div class="cart-icon-wrapper">
+            <span class="cart-icon">&#128722;</span>
+        </div>
+
+        <p class="intro">
+            <strong>{{ $customerName }}</strong> ha registrado una compra en Socomarca Compra Rápida.
+        </p>
+
+        <p class="order-summary">
+            Pedido <strong>N&deg;{{ $order->id }}</strong> - Total <strong>${{ number_format($total, 0, ',', '.') }}</strong>
+            @if ($orderDate) - {{ $orderDate }} @endif
+        </p>
+
+        <h3 class="section-title">Detalle de la compra</h3>
+
+        @foreach ($order->orderDetails as $item)
+            @php
+                $product = $item->product;
+                $imageUrl = $product?->image_url
+                    ?? $product?->image
+                    ?? $product?->thumbnail
+                    ?? null;
+                $lineTotal = (int) round($item->price * $item->quantity);
+            @endphp
+            <div class="product-row">
+                <div class="product-image">
+                    @if (! empty($imageUrl))
+                        <img src="{{ $imageUrl }}" alt="{{ $product?->name ?? 'Producto' }}" />
+                    @else
+                        Producto
+                    @endif
+                </div>
+                <div class="product-info">
+                    <div class="product-name">{{ $product?->name ?? 'Producto' }}</div>
+                    <div class="product-meta">Cantidad: {{ $item->quantity }}{{ $item->unit ? ' ' . $item->unit : '' }}</div>
+                </div>
+                <div class="product-price">${{ number_format($lineTotal, 0, ',', '.') }}</div>
+            </div>
+        @endforeach
+
+        <table class="meta-totals-table" cellpadding="0" cellspacing="0">
+            <tr>
+                <td class="meta-col">
+                    <div class="meta-block">
+                        <p class="meta-label">M&eacute;todo de pago</p>
+                        <p class="meta-value">{{ $paymentMethodLabel }}</p>
+                    </div>
+                    <div class="meta-block">
+                        <p class="meta-label">Forma de env&iacute;o</p>
+                        <p class="meta-value">{{ $shippingMethodLabel }}</p>
+                    </div>
+                    @if (! empty($order->notes))
+                        <div class="meta-block">
+                            <p class="meta-label">Nota</p>
+                            <p class="meta-value">{{ $order->notes }}</p>
+                        </div>
+                    @endif
+                </td>
+                <td class="totals-col">
+                    <table class="totals-table" cellpadding="0" cellspacing="0">
+                        <tr>
+                            <td class="label-col">Subtotal</td>
+                            <td class="amount-col">${{ number_format($subtotal, 0, ',', '.') }}</td>
+                        </tr>
+                        <tr>
+                            <td class="label-col">Descuento</td>
+                            <td class="amount-col">-${{ number_format($discount, 0, ',', '.') }}</td>
+                        </tr>
+                        <tr>
+                            <td class="label-col">Env&iacute;o</td>
+                            <td class="amount-col">${{ number_format($shippingCost, 0, ',', '.') }}</td>
+                        </tr>
+                        <tr>
+                            <td class="label-col">Pedido reembolsado</td>
+                            <td class="amount-col">-${{ number_format($refund, 0, ',', '.') }}</td>
+                        </tr>
+                        <tr>
+                            <td class="label-col">Reembolso</td>
+                            <td class="amount-col">-$0</td>
+                        </tr>
+                        <tr class="total">
+                            <td class="label-col">Total</td>
+                            <td class="amount-col">${{ number_format($total, 0, ',', '.') }}</td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+        </table>
+
+        <table class="addresses-table" cellpadding="0" cellspacing="0">
+            <tr>
+                <th>Direcci&oacute;n de facturaci&oacute;n</th>
+                <th>Direcci&oacute;n de env&iacute;o</th>
+            </tr>
+            <tr>
+                <td>
+                    {{ $customerName }}<br />
+                    @if (! empty($billingAddress['address_line1']))
+                        {{ $billingAddress['address_line1'] }}@if (! empty($billingAddress['address_line2'])), {{ $billingAddress['address_line2'] }}@endif<br />
+                    @endif
+                    @if (! empty($billingAddress['postal_code'])) {{ $billingAddress['postal_code'] }}<br /> @endif
+                    @if (! empty($customer?->phone)) {{ $customer->phone }}<br /> @endif
+                    {{ $customer?->email }}
+                </td>
+                <td>
+                    {{ $customerName }}<br />
+                    @if (! empty($shippingAddress['address_line1']))
+                        {{ $shippingAddress['address_line1'] }}@if (! empty($shippingAddress['address_line2'])), {{ $shippingAddress['address_line2'] }}@endif<br />
+                    @endif
+                    @if (! empty($shippingAddress['postal_code'])) {{ $shippingAddress['postal_code'] }}<br /> @endif
+                    @if (! empty($customer?->phone)) {{ $customer->phone }}<br /> @endif
+                    {{ $customer?->email }}
+                </td>
+            </tr>
+        </table>
+        <!--
+        <div class="footer">
+            <div class="tagline">Socomarca Compra Rápida</div>
+            <div class="social">
+                <a href="#" aria-label="Facebook">f</a>
+                <a href="#" aria-label="Twitter">t</a>
+                <a href="#" aria-label="Instagram">i</a>
+                <a href="#" aria-label="YouTube">y</a>
+                <a href="#" aria-label="Pinterest">p</a>
+            </div>
+            <div class="sent-by">Este correo fue enviado por: contacto@socomarca.cl</div>
+            <div class="contact">Por cualquier duda comunicarse a contacto@socomarca.cl</div>
+        </div>
+        -->
+    </div>
+</body>
+</html>

--- a/tests/Feature/Listeners/SendOrderCompletedEmailTest.php
+++ b/tests/Feature/Listeners/SendOrderCompletedEmailTest.php
@@ -1,0 +1,164 @@
+<?php
+
+use App\Events\OrderCompleted;
+use App\Listeners\SendOrderCompletedEmail;
+use App\Mail\OrderCompletedMail;
+use App\Models\Branch;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\Payment;
+use App\Models\PaymentMethod;
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+
+/**
+ * Create a fully populated completed-order scenario with all related entities.
+ *
+ * @return array{
+ *     user: User,
+ *     branch: Branch,
+ *     paymentMethod: PaymentMethod,
+ *     order: Order,
+ *     product: Product
+ * }
+ */
+function makeCompletedOrderScenario(): array
+{
+    $user = User::factory()->create();
+    $branch = Branch::factory()->create();
+    $paymentMethod = PaymentMethod::factory()->create([
+        'code' => 'webpay',
+        'name' => 'Webpay',
+    ]);
+    $order = Order::factory()->completed()->create([
+        'user_id' => $user->id,
+        'branch_id' => $branch->id,
+        'amount' => 55000,
+        'subtotal' => 45000,
+        'shipping_cost' => 10000,
+    ]);
+    $product = Product::factory()->create(['name' => 'Sample product']);
+    OrderItem::factory()->create([
+        'order_id' => $order->id,
+        'product_id' => $product->id,
+        'quantity' => 1,
+        'price' => 25000,
+        'unit' => 'kg',
+    ]);
+    Payment::factory()->create([
+        'order_id' => $order->id,
+        'payment_method_id' => $paymentMethod->id,
+        'response_status' => 'AUTHORIZED',
+    ]);
+
+    return [
+        'user' => $user,
+        'branch' => $branch,
+        'paymentMethod' => $paymentMethod,
+        'order' => $order,
+        'product' => $product,
+    ];
+}
+
+test('sends the order completed email to the warehouse recipient', function () {
+    Mail::fake();
+
+    ['order' => $order] = makeCompletedOrderScenario();
+    $recipient = config('random.warehouse_email_recipient');
+    expect($recipient)->not->toBeEmpty();
+
+    (new SendOrderCompletedEmail)->handle(new OrderCompleted($order));
+
+    Mail::assertSent(OrderCompletedMail::class, function (OrderCompletedMail $mail) use ($recipient, $order) {
+        return $mail->hasTo($recipient)
+            && $mail->order->id === $order->id;
+    });
+});
+
+test('email subject contains customer name and order number', function () {
+    Mail::fake();
+
+    ['user' => $user, 'order' => $order] = makeCompletedOrderScenario();
+
+    (new SendOrderCompletedEmail)->handle(new OrderCompleted($order));
+
+    Mail::assertSent(OrderCompletedMail::class, function (OrderCompletedMail $mail) use ($user, $order) {
+        $subject = $mail->envelope()->subject;
+
+        return str_contains($subject, $user->name)
+            && str_contains($subject, (string) $order->id)
+            && str_contains($subject, 'SOCOMARCA');
+    });
+});
+
+test('email body renders the order summary view', function () {
+    Mail::fake();
+
+    ['user' => $user, 'order' => $order, 'product' => $product] = makeCompletedOrderScenario();
+
+    (new SendOrderCompletedEmail)->handle(new OrderCompleted($order));
+
+    Mail::assertSent(OrderCompletedMail::class, function (OrderCompletedMail $mail) use ($user, $order, $product) {
+        $rendered = $mail->render();
+        $logoUrl = config('random.site_logo_url');
+
+        return str_contains($rendered, 'Pedido')
+            && str_contains($rendered, (string) $order->id)
+            && str_contains($rendered, $user->name)
+            && str_contains($rendered, $product->name)
+            && str_contains($rendered, $logoUrl);
+    });
+});
+
+test('logo URL is read from config random site_logo_url', function () {
+    Mail::fake();
+
+    ['order' => $order] = makeCompletedOrderScenario();
+
+    (new SendOrderCompletedEmail)->handle(new OrderCompleted($order));
+
+    Mail::assertSent(OrderCompletedMail::class, function (OrderCompletedMail $mail) {
+        return str_contains($mail->render(), 'src="'.config('random.site_logo_url').'"');
+    });
+});
+
+test('does not send email when warehouse recipient is not configured', function () {
+    Mail::fake();
+    config()->set('random.warehouse_email_recipient', null);
+
+    ['order' => $order] = makeCompletedOrderScenario();
+
+    (new SendOrderCompletedEmail)->handle(new OrderCompleted($order));
+
+    Mail::assertNothingSent();
+});
+
+test('does not send email when warehouse recipient is empty string', function () {
+    Mail::fake();
+    config()->set('random.warehouse_email_recipient', '');
+
+    ['order' => $order] = makeCompletedOrderScenario();
+
+    (new SendOrderCompletedEmail)->handle(new OrderCompleted($order));
+
+    Mail::assertNothingSent();
+});
+
+test('listener implements ShouldQueue', function () {
+    expect(new SendOrderCompletedEmail)->toBeInstanceOf(ShouldQueue::class);
+});
+
+test('listener handles event dispatched via the event system', function () {
+    Mail::fake();
+
+    ['order' => $order] = makeCompletedOrderScenario();
+
+    OrderCompleted::dispatch($order);
+
+    Mail::assertSent(OrderCompletedMail::class, function (OrderCompletedMail $mail) use ($order) {
+        return $mail->order->id === $order->id;
+    });
+});

--- a/tests/Feature/ProductTest.php
+++ b/tests/Feature/ProductTest.php
@@ -983,6 +983,56 @@ describe("Product search endpoint", function (): void {
     );
 
     it(
+        "should find products with typos using fuzzy search",
+        function (): void {
+            $priceListCode = "01P";
+            $user = App\Models\User::factory()->create([
+                "prices_lists" => [$priceListCode],
+            ]);
+            $user->givePermissionTo("read-all-products");
+            Product::truncate();
+
+            Product::factory()
+                ->has(
+                    Price::factory([
+                        "price" => 5000,
+                        "is_active" => true,
+                        "stock" => 10,
+                        "price_list_id" => $priceListCode,
+                    ]),
+                )
+                ->create(["name" => "Arroz Premium 1kg", "status" => true]);
+
+            Product::factory()
+                ->has(
+                    Price::factory([
+                        "price" => 3000,
+                        "is_active" => true,
+                        "stock" => 10,
+                        "price_list_id" => $priceListCode,
+                    ]),
+                )
+                ->create(["name" => "Fideos Guiso", "status" => true]);
+
+            $response = actingAs($user, "sanctum")->postJson(
+                route("products.search"),
+                [
+                    "filters" => [
+                        "price" => ["min" => 0, "max" => 10000],
+                        "name" => "arros",
+                    ],
+                ],
+            );
+
+            $response->assertStatus(200);
+            expect($response->json("data"))->not->toBeEmpty();
+            $names = array_column($response->json("data"), "name");
+            expect($names)->toContain("Arroz Premium 1kg");
+            expect($names)->not->toContain("Fideos Guiso");
+        },
+    );
+
+    it(
         "should exclude inactive prices when filtering zero price products",
         function (): void {
             $priceListCode = "01P";


### PR DESCRIPTION
- Replace similarity() with word_similarity() in applyNameFilter
- word_similarity compares against individual words in the name
- Enables finding products with typos (e.g. "arros" → "Arroz")
- Add test to verify typo-tolerant search