### PR TITLE
feat(products): exponer price_list_id en el listado de productos

### DIFF
--- a/app/Http/Resources/Products/ProductCollection.php
+++ b/app/Http/Resources/Products/ProductCollection.php
@@ -49,8 +49,8 @@ class ProductCollection extends ResourceCollection
                 'unit' => $product->joined_unit,
                 'price' => (float) $product->joined_price,
                 'stock' => (int) $product->joined_stock,
-                // Lista de precios a la que corresponde esta fila. El valor es el nombre
-                // legible que entrega Random; un producto se repite una vez por lista.
+                // Price list this row belongs to. The stored value is the human readable
+                // name coming from Random; a product repeats once per price list.
                 'price_list_id' => $product->joined_price_list_id,
                 'image' => $imageUrl ?? null,
                 'sku' => $product->sku ?? null,

--- a/app/Http/Resources/Products/ProductCollection.php
+++ b/app/Http/Resources/Products/ProductCollection.php
@@ -49,6 +49,9 @@ class ProductCollection extends ResourceCollection
                 'unit' => $product->joined_unit,
                 'price' => (float) $product->joined_price,
                 'stock' => (int) $product->joined_stock,
+                // Lista de precios a la que corresponde esta fila. El valor es el nombre
+                // legible que entrega Random; un producto se repite una vez por lista.
+                'price_list_id' => $product->joined_price_list_id,
                 'image' => $imageUrl ?? null,
                 'sku' => $product->sku ?? null,
                 'is_favorite' => $isFavorite,

--- a/app/Services/Data/ProductQueryService.php
+++ b/app/Services/Data/ProductQueryService.php
@@ -26,7 +26,10 @@ class ProductQueryService
      * Get paginated products with prices joined from user's allowed price lists.
      *
      * Returns one row per product-price combination (variant). Each variant includes
-     * joined_price, joined_stock, and joined_unit from the prices table.
+     * joined_price, joined_stock, joined_unit and joined_price_list_id from the prices table.
+     *
+     * A product repeats once per allowed price list (and per unit within a list), so
+     * joined_price_list_id is what tells apart which list each row comes from.
      *
      * @param int $perPage Number of items per page
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
@@ -41,6 +44,7 @@ class ProductQueryService
             'prices.price as joined_price',
             'prices.stock as joined_stock',
             'prices.unit as joined_unit',
+            'prices.price_list_id as joined_price_list_id',
         );
 
         return $query->paginate($perPage);

--- a/tests/Scenarios/ProductScenario.php
+++ b/tests/Scenarios/ProductScenario.php
@@ -18,6 +18,7 @@ class ProductScenario
                     "unit",
                     "price",
                     "stock",
+                    "price_list_id",
                     "image",
                     "sku",
                     "is_favorite",


### PR DESCRIPTION
## Problema

En el listado de productos del panel de administración un mismo producto aparece repetido varias veces, sin nada que permita distinguir las filas entre sí.

No es un problema de renderizado. `ProductQueryService::getPaginatedProductsWithAllowedPrices()` hace un INNER JOIN contra `prices` filtrando por las listas de precios permitidas del usuario, así que la consulta devuelve **una fila por cada combinación producto-precio**, no una por producto. Como un producto puede tener precio en varias listas (y más de una unidad dentro de la misma lista, según el índice único `prices_product_list_unit_unique`), se repite una vez por cada caso.

## Solución

`prices.price_list_id` ya almacena el nombre legible de la lista, pero no se estaba exponiendo. El cambio se limita a sacarlo a la respuesta:

- `ProductQueryService`: se agrega `prices.price_list_id as joined_price_list_id` al `select`.
- `ProductCollection`: se incluye `price_list_id` en el payload.
- `ProductScenario`: se suma el campo a la estructura esperada en los tests.

No agrega consultas ni cambia el conjunto de resultados: el dato ya viajaba en el JOIN, solo faltaba seleccionarlo. Tampoco hay migraciones ni cambios en la sincronización con Random.